### PR TITLE
Update fastapi_app header comment

### DIFF
--- a/src/interfaces/api/fastapi_app.py
+++ b/src/interfaces/api/fastapi_app.py
@@ -1,4 +1,4 @@
-# src/rag_facade.py
+# fastapi_app.py - FastAPI interface for queuing RAG jobs
 
 import uuid
 from typing import Dict, Any


### PR DESCRIPTION
## Summary
- fix incorrect header comment in `fastapi_app.py`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'services')*