### PR TITLE
Add comprehensive unit tests for core modules

### DIFF
--- a/tests/application/test_prompt_builder.py
+++ b/tests/application/test_prompt_builder.py
@@ -1,0 +1,402 @@
+import pytest
+from unittest.mock import patch, MagicMock
+import types
+
+from rag_core.application.prompt_builder import PromptBuilder
+from rag_core.exceptions import PromptTooLongError
+
+# A simple mock for the Scenario pydantic model
+class MockScenario:
+    def __init__(self,
+                 llm_name="test_llm",
+                 max_prompt_tokens=1000,
+                 direction="forward",
+                 role_desc="Test Role",
+                 reference_desc="Test Reference",
+                 input_desc="Test Input",
+                 scoring_rule="Test Scoring Rule",
+                 cof_threshold=0.1):
+        self.llm_name = llm_name
+        self.max_prompt_tokens = max_prompt_tokens
+        self.direction = direction
+        self.role_desc = role_desc
+        self.reference_desc = reference_desc
+        self.input_desc = input_desc
+        self.scoring_rule = scoring_rule
+        self.cof_threshold = cof_threshold
+
+@pytest.fixture
+def mock_token_counter(mocker):
+    """Fixture to mock TokenCounter.count."""
+    return mocker.patch('rag_core.application.prompt_builder.TokenCounter.count')
+
+def test_build_prompt_basic_generation(mock_token_counter):
+    """
+    Scenario 1: Basic prompt generation.
+    - Mock TokenCounter.count to return a fixed value.
+    - Provide a simple user_query, context_docs, and a scenario.
+    - Assert that the generated prompt string contains the user_query and content from context_docs.
+    - Assert that the returned number of used candidates is correct.
+    """
+    # Arrange
+    mock_token_counter.return_value = 10  # Each string costs 10 tokens
+
+    prompt_builder = PromptBuilder()
+    user_query = "What is the capital of France?"
+    context_docs = [
+        {'uid': 'doc1', 'text': 'Paris is the capital of France.', 'score': 0.9},
+        {'uid': 'doc2', 'text': 'France is a country in Europe.', 'score': 0.8},
+    ]
+    scenario = MockScenario(max_prompt_tokens=200) # Header (10) + Query (10) + NL (10) +  Ref (10) + Cand1 (10) + NL (10) + Cand2 (10) = 70 tokens, well within limits
+
+    # Act
+    prompt, num_used_candidates = prompt_builder.build_prompt(
+        user_query=user_query,
+        context_docs=context_docs,
+        scenario=scenario
+    )
+
+    # Assert
+    assert user_query in prompt
+    assert "Paris is the capital of France." in prompt
+    assert "France is a country in Europe." in prompt
+    assert num_used_candidates == 2
+
+    # Verify TokenCounter.count was called for header, query, and each candidate text
+    # Header parts: role_desc, direction, reference_desc, input_desc, scoring_rule
+    # Plus the query, newlines, and each document's text.
+    # The exact number of calls can be tricky due to internal formatting,
+    # so we'll check key calls for now.
+    
+    # Expected calls:
+    # 1. Header string (constructed internally)
+    # 2. User query
+    # 3. Newline after query
+    # 4. Reference section header
+    # 5. Candidate 1 text
+    # 6. Newline after candidate 1
+    # 7. Candidate 2 text
+    # (No newline after last candidate in current implementation)
+
+    # A more robust check would be to verify calls with specific arguments if needed,
+    # but for now, let's check if it was called multiple times.
+    assert mock_token_counter.call_count > 5 
+    mock_token_counter.assert_any_call(scenario.llm_name, user_query)
+    mock_token_counter.assert_any_call(scenario.llm_name, context_docs[0]['text'])
+    mock_token_counter.assert_any_call(scenario.llm_name, context_docs[1]['text'])
+
+    # Check that the prompt structure is roughly as expected
+    assert f"【Role】\n{scenario.role_desc}" in prompt
+    assert f"【模式】\n{scenario.direction}" in prompt
+    assert f"【參考資料】\n{scenario.reference_desc}" in prompt
+    assert f"【任務】\n{scenario.input_desc}" in prompt
+    assert f"【評分規則】\n{scenario.scoring_rule}" in prompt
+    assert f"【Query】\n{user_query}" in prompt
+    assert f"【Candidate 1】(uid: doc1, score: 0.9)\n{context_docs[0]['text']}" in prompt
+    assert f"【Candidate 2】(uid: doc2, score: 0.8)\n{context_docs[1]['text']}" in prompt
+
+def test_build_prompt_too_long_header_query_exceeds_max(mock_token_counter):
+    """
+    Scenario 2: Prompt too long (header + query exceeds max_tokens).
+    - Mock TokenCounter.count such that the initial count for header and query
+      exceeds scenario.max_prompt_tokens.
+    - Use pytest.raises to assert that PromptTooLongError is raised.
+    """
+    # Arrange
+    # Mock TokenCounter.count to return a value that makes header + query too long
+    # Let header cost 60 tokens and query cost 50 tokens. Total = 110 tokens.
+    def side_effect_count(llm_name, text_to_count):
+        if text_to_count == "What is the capital of France?":
+            return 50  # Query tokens
+        # For any other text (assume it's part of the header construction)
+        return 10 # Fixed value for other parts of header, let's say header is constructed of 6 such parts.
+
+    mock_token_counter.side_effect = side_effect_count
+
+    prompt_builder = PromptBuilder()
+    user_query = "What is the capital of France?"
+    context_docs = [
+        {'uid': 'doc1', 'text': 'Paris is the capital of France.', 'score': 0.9}
+    ]
+    # max_prompt_tokens is 100, but header (6*10=60) + query (50) = 110
+    scenario = MockScenario(max_prompt_tokens=100)
+
+    # Act & Assert
+    with pytest.raises(PromptTooLongError) as excinfo:
+        prompt_builder.build_prompt(
+            user_query=user_query,
+            context_docs=context_docs,
+            scenario=scenario
+        )
+    assert "Header 和 Query 的總長度" in str(excinfo.value)
+    assert "已經超過 max_prompt_tokens" in str(excinfo.value)
+
+def test_build_prompt_too_long_no_candidates_fit(mock_token_counter):
+    """
+    Scenario 3: Prompt too long (no candidates can fit).
+    - Mock TokenCounter.count such that header and query fit, but adding
+      the token count of the first candidate (and the newline after it)
+      exceeds scenario.max_prompt_tokens.
+    - Use pytest.raises to assert that PromptTooLongError is raised with a
+      message indicating no candidates could be added.
+    """
+    # Arrange
+    # Header (e.g. 6 parts * 5 tokens/part = 30) + Query (20) + NL (5) = 55 tokens.
+    # First candidate (50) + NL (5) = 55 tokens.
+    # Total with first candidate = 55 + 55 = 110 tokens.
+    # Max tokens = 100.
+    def side_effect_count(llm_name, text_to_count):
+        if text_to_count == "What is the capital of France?":
+            return 20  # Query tokens
+        elif "Paris is the capital of France." in text_to_count:
+            return 50  # First candidate tokens
+        elif text_to_count == "\n":
+            return 5 # Newline tokens
+        # For any other text (assume it's part of the header construction or reference header)
+        return 5
+
+    mock_token_counter.side_effect = side_effect_count
+
+    prompt_builder = PromptBuilder()
+    user_query = "What is the capital of France?"
+    context_docs = [
+        {'uid': 'doc1', 'text': 'Paris is the capital of France.', 'score': 0.9},
+        {'uid': 'doc2', 'text': 'France is a country in Europe.', 'score': 0.8},
+    ]
+    scenario = MockScenario(max_prompt_tokens=100) # Header (30) + Query (20) + NL(5) + Ref_Header(5) = 60. Remaining 40. First cand (50) too big.
+
+    # Act & Assert
+    with pytest.raises(PromptTooLongError) as excinfo:
+        prompt_builder.build_prompt(
+            user_query=user_query,
+            context_docs=context_docs,
+            scenario=scenario
+        )
+    assert "沒有任何 Candidate 能放進 prompt" in str(excinfo.value)
+    assert "請調整 max_prompt_tokens 或減少 context_docs 數量" in str(excinfo.value)
+
+
+def test_build_prompt_candidates_truncation(mock_token_counter):
+    """
+    Scenario 4: Candidates truncation.
+    - Provide multiple context_docs (e.g., 3 docs).
+    - Mock TokenCounter.count such that header + query + candidate1 + candidate2 fits,
+      but header + query + candidate1 + candidate2 + candidate3 exceeds scenario.max_prompt_tokens.
+    - Assert that the prompt includes only the first two candidates.
+    - Assert that the returned number of used candidates is 2.
+    """
+    # Arrange
+    # Header (30) + Query (20) + NL (5) + Ref_Header (5) = 60 tokens.
+    # Cand1 (10) + NL (5) = 15
+    # Cand2 (10) + NL (5) = 15
+    # Cand3 (10)
+    # Total with 2 cands = 60 + 15 + 15 = 90 tokens.
+    # Total with 3 cands = 60 + 15 + 15 + 10 = 100 tokens. (If no NL after last)
+    # Let max_tokens = 95. So Cand3 should be excluded.
+    # If NL is added after last candidate, then Total with 2 cands = 60 + 15 + 15 = 90 tokens.
+    # Total with 3 cands = 60 + 15 + 15 + 15 = 105 tokens.
+    # Let's assume NL is not added after the last candidate based on current prompt structure.
+
+    def side_effect_count(llm_name, text_to_count):
+        if text_to_count == "What is the capital of France?":
+            return 20  # Query tokens
+        elif "Candidate 1 text" in text_to_count: # context_docs[0]
+            return 10
+        elif "Candidate 2 text" in text_to_count: # context_docs[1]
+            return 10
+        elif "Candidate 3 text" in text_to_count: # context_docs[2]
+            return 10 # This one should make it exceed
+        elif text_to_count == "\n":
+            return 5 # Newline tokens
+        # For any other text (assume it's part of the header construction or reference header)
+        return 5 # e.g. role_desc, direction, reference_desc, input_desc, scoring_rule, ref_header_text. (6 * 5 = 30 for header)
+
+    mock_token_counter.side_effect = side_effect_count
+
+    prompt_builder = PromptBuilder()
+    user_query = "What is the capital of France?"
+    context_docs = [
+        # These will be sorted by score by PromptBuilder
+        {'uid': 'doc3', 'text': 'Candidate 3 text', 'score': 0.7},
+        {'uid': 'doc1', 'text': 'Candidate 1 text (High score)', 'score': 0.9},
+        {'uid': 'doc2', 'text': 'Candidate 2 text (Mid score)', 'score': 0.8},
+    ]
+    # Header(30) + Query(20) + NL(5) + Ref_Header(5) = 60
+    # Cand1_text(10) + NL(5) = 15. Total = 75
+    # Cand2_text(10) (no NL after last) = 10. Total = 85. This fits.
+    # If Cand2 has NL: Cand2_text(10) + NL(5) = 15. Total = 90. This fits.
+    # Cand3_text(10). Total = 90 + 10 = 100. This exceeds.
+    # Let's set max_prompt_tokens to 95.
+    scenario = MockScenario(max_prompt_tokens=95)
+
+
+    # Act
+    prompt, num_used_candidates = prompt_builder.build_prompt(
+        user_query=user_query,
+        context_docs=context_docs,
+        scenario=scenario
+    )
+
+    # Assert
+    assert "Candidate 1 text (High score)" in prompt
+    assert "Candidate 2 text (Mid score)" in prompt
+    assert "Candidate 3 text" not in prompt
+    assert num_used_candidates == 2
+
+    # Check order due to sorting
+    assert prompt.find("Candidate 1 text (High score)") < prompt.find("Candidate 2 text (Mid score)")
+
+    # Verify token counts.
+    # Header (6*5=30) + Query (20) + NL (5) + Ref Header (5) = 60
+    # Cand1 (uid: doc1, score: 0.9) + text (10) + NL (5) = 15 (text is 'Candidate 1 text (High score)')
+    # Cand2 (uid: doc2, score: 0.8) + text (10) = 10 (text is 'Candidate 2 text (Mid score)')
+    # Expected total tokens = 60 + 15 + 10 = 85. This is <= 95.
+    # If we add Cand3 (text: 10 tokens) + NL (5), total would be 85 + 10 + 5 = 100. (If NL after each)
+    # If no NL after last: 85 + 10 = 95. This would fit exactly.
+    # The prompt format is "【Candidate X】(...)\n{text}\n" for all but last, and "【Candidate X】(...)\n{text}" for last.
+    # So, after Cand1: 60 + 10(text) + 5(NL) = 75. (Assuming 【Candidate X】(...) part has 0 token cost based on mock)
+    # After Cand2: 75 + 10(text) = 85. (No NL after last one)
+    # Adding Cand3: 85 (current_prompt) + 5 (NL for previous cand2) + 10 (cand3 text) = 100. This exceeds 95.
+    # So, yes, only 2 candidates should be used.
+
+    # Let's refine the side_effect to be more explicit about what text gets what token count
+    # to make the test less fragile.
+    # Header parts: role_desc, direction, reference_desc, input_desc, scoring_rule (5 * 5 = 25)
+    # Query (20)
+    # NL_after_query (5)
+    # Ref_header_text (5)
+    # Total fixed part = 25 + 20 + 5 + 5 = 55
+    #
+    # Candidate 1 (doc1, score 0.9): Text="Candidate 1 text (High score)" (10 tokens)
+    #   - Cand_Header_String: "【Candidate 1】(uid: doc1, score: 0.9)\n" (let's say 5 tokens for this wrapper)
+    #   - Cand_Text: 10 tokens
+    #   - NL_after_cand_text: 5 tokens
+    #   Total for Cand1 block = 5 + 10 + 5 = 20 tokens.
+    #   Prompt total = 55 + 20 = 75 tokens.
+    #
+    # Candidate 2 (doc2, score 0.8): Text="Candidate 2 text (Mid score)" (10 tokens)
+    #   - Cand_Header_String: "【Candidate 2】(uid: doc2, score: 0.8)\n" (5 tokens)
+    #   - Cand_Text: 10 tokens
+    #   (No NL after last candidate's text in the current prompt structure)
+    #   Total for Cand2 block = 5 + 10 = 15 tokens.
+    #   Prompt total = 75 + 15 = 90 tokens. This fits within 95.
+    #
+    # Candidate 3 (doc3, score 0.7): Text="Candidate 3 text" (10 tokens)
+    #   - Add NL for previous candidate (Cand2): 5 tokens. Current total = 90 + 5 = 95.
+    #   - Cand_Header_String: "【Candidate 3】(uid: doc3, score: 0.7)\n" (5 tokens)
+    #   - Cand_Text: 10 tokens
+    #   Total for Cand3 block = 5 + 10 = 15 tokens.
+    #   Hypothetical prompt total = 95 (prompt_after_NL_for_cand2) + 5 (cand3_header) + 10 (cand3_text) = 110. This exceeds 95.
+    #
+    # So the logic holds.
+
+def test_build_prompt_different_directions(mock_token_counter):
+    """
+    Scenario 5: Different directions (forward/reverse).
+    - Create two scenario objects, one with direction="forward" and another with direction="reverse".
+    - Mock TokenCounter.count to allow all content to fit.
+    - Assert that the direction-specific text (e.g., "【模式】\nforward" or "【模式】\nreverse")
+      appears in the respective prompts.
+    """
+    # Arrange
+    mock_token_counter.return_value = 1 # Make token counts negligible
+
+    prompt_builder = PromptBuilder()
+    user_query = "Test query"
+    context_docs = [{'uid': 'doc1', 'text': 'Test content', 'score': 0.9}]
+
+    scenario_forward = MockScenario(direction="forward", max_prompt_tokens=200)
+    scenario_reverse = MockScenario(direction="reverse", max_prompt_tokens=200)
+
+    # Act
+    prompt_forward, _ = prompt_builder.build_prompt(
+        user_query=user_query,
+        context_docs=context_docs,
+        scenario=scenario_forward
+    )
+    prompt_reverse, _ = prompt_builder.build_prompt(
+        user_query=user_query,
+        context_docs=context_docs,
+        scenario=scenario_reverse
+    )
+
+    # Assert
+    assert "【模式】\nforward" in prompt_forward
+    assert "【模式】\nreverse" in prompt_reverse
+    assert "【模式】\nreverse" not in prompt_forward
+    assert "【模式】\nforward" not in prompt_reverse
+
+def test_build_prompt_empty_context_docs(mock_token_counter):
+    """
+    Scenario 6: Empty context_docs.
+    - Call build_prompt with an empty context_docs list.
+    - Mock TokenCounter.count as needed.
+    - Use pytest.raises to assert that PromptTooLongError is raised.
+    """
+    # Arrange
+    mock_token_counter.return_value = 1 # Token counts don't matter much here, just need to avoid other errors.
+    prompt_builder = PromptBuilder()
+    user_query = "Test query"
+    scenario = MockScenario(max_prompt_tokens=200)
+
+    # Act & Assert
+    with pytest.raises(PromptTooLongError) as excinfo:
+        prompt_builder.build_prompt(
+            user_query=user_query,
+            context_docs=[], # Empty list
+            scenario=scenario
+        )
+    # Based on current implementation, it raises error if _candidates_str is empty.
+    assert "沒有任何 Candidate 能放進 prompt" in str(excinfo.value)
+
+def test_build_prompt_custom_llm_name_in_scenario(mock_token_counter):
+    """
+    Scenario 7: Custom llm_name in scenario.
+    - Provide a scenario with a specific llm_name (e.g., "custom_model_test").
+    - Mock TokenCounter.count and ensure it's called with this llm_name
+      for token counting.
+    """
+    # Arrange
+    mock_token_counter.return_value = 1 # Token counts don't matter, just checking calls
+    custom_llm_name = "custom_model_test_001"
+
+    prompt_builder = PromptBuilder()
+    user_query = "Test query for custom LLM."
+    context_docs = [
+        {'uid': 'doc1', 'text': 'Content for custom LLM.', 'score': 0.9},
+    ]
+    scenario = MockScenario(llm_name=custom_llm_name, max_prompt_tokens=500)
+
+    # Act
+    prompt_builder.build_prompt(
+        user_query=user_query,
+        context_docs=context_docs,
+        scenario=scenario
+    )
+
+    # Assert
+    # Check that all calls to TokenCounter.count used the custom_llm_name
+    # Important texts that should be counted:
+    # - scenario.role_desc
+    # - scenario.direction
+    # - scenario.reference_desc
+    # - scenario.input_desc
+    # - scenario.scoring_rule
+    # - user_query
+    # - "\n" (newlines)
+    # - "【參考資料】" (reference header text)
+    # - context_docs[0]['text']
+    # - "【Query】" (query header text)
+    # - f"【Candidate 1】(uid: {context_docs[0]['uid']}, score: {context_docs[0]['score']})\n" (candidate header)
+
+    # We can check a few key ones explicitly
+    mock_token_counter.assert_any_call(custom_llm_name, scenario.role_desc)
+    mock_token_counter.assert_any_call(custom_llm_name, user_query)
+    mock_token_counter.assert_any_call(custom_llm_name, context_docs[0]['text'])
+
+    # More general check: iterate through all calls
+    for call_args in mock_token_counter.call_args_list:
+        args, _ = call_args
+        assert args[0] == custom_llm_name, f"TokenCounter.count called with incorrect llm_name: {args[0]}"
+
+# No more tests for now. End of file.

--- a/tests/application/test_rag_engine.py
+++ b/tests/application/test_rag_engine.py
@@ -1,0 +1,515 @@
+import pytest
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, Mock, patch
+
+from rag_core.application.rag_engine import RAGEngine
+from rag_core.exceptions import EmbeddingError, VectorSearchError, PromptTooLongError, LLMError
+
+# A simple mock for the Scenario pydantic model
+class MockScenario:
+    def __init__(self,
+                 direction="forward",
+                 rag_k_forward=5,
+                 rag_k_reverse=3,
+                 rag_k=4, # Fallback
+                 llm_name="default_llm", # Can be overridden by test
+                 max_prompt_tokens=1000, # For PromptBuilder, though not directly used by RAGEngine tests often
+                 role_desc="Test Role",
+                 reference_desc="Test Reference",
+                 input_desc="Test Input",
+                 scoring_rule="Test Scoring Rule",
+                 cof_threshold=0.1):
+        self.direction = direction
+        self.rag_k_forward = rag_k_forward
+        self.rag_k_reverse = rag_k_reverse
+        self.rag_k = rag_k
+        self.llm_name = llm_name
+        self.max_prompt_tokens = max_prompt_tokens
+        self.role_desc = role_desc
+        self.reference_desc = reference_desc
+        self.input_desc = input_desc
+        self.scoring_rule = scoring_rule
+        self.cof_threshold = cof_threshold
+
+@pytest.fixture
+def mock_embedding_manager():
+    manager = AsyncMock()
+    manager.generate_embedding_async = AsyncMock(return_value=[0.1, 0.2, 0.3])
+    return manager
+
+@pytest.fixture
+def mock_vector_index():
+    index = AsyncMock()
+    index.search_async = AsyncMock(return_value=[
+        {'uid': 'doc1', 'text': 'Document 1 text', 'score': 0.9},
+        {'uid': 'doc2', 'text': 'Document 2 text', 'score': 0.8},
+    ])
+    return index
+
+@pytest.fixture
+def mock_llm_manager():
+    manager = MagicMock() # Use MagicMock to allow attribute assignment like default_adapter_name
+    mock_adapter = AsyncMock()
+    mock_adapter.async_generate_response = AsyncMock(return_value="LLM generated answer.")
+    manager.get_adapter = MagicMock(return_value=mock_adapter)
+    manager.default_adapter_name = "default_llm_adapter"
+    return manager
+
+@pytest.fixture
+def mock_prompt_builder(mocker):
+    # Patch PromptBuilder where it's used by RAGEngine
+    mock_pb_instance = MagicMock()
+    mock_pb_instance.build_prompt = MagicMock(return_value=("Formatted prompt string", 2)) # prompt, num_candidates
+    
+    # Mock the class constructor to return our instance
+    # The path should be where PromptBuilder is imported/used by RAGEngine
+    mocker.patch('rag_core.application.rag_engine.PromptBuilder', return_value=mock_pb_instance)
+    return mock_pb_instance
+
+
+@pytest.fixture
+def mock_result_formatter(mocker):
+    mock_rf_instance = MagicMock()
+    mock_rf_instance.parse_and_format = MagicMock(return_value=[{"formatted": "result"}])
+
+    # Mock the class constructor to return our instance
+    # The path should be where ResultFormatter is imported/used by RAGEngine
+    mocker.patch('rag_core.application.rag_engine.ResultFormatter', return_value=mock_rf_instance)
+    return mock_rf_instance
+
+
+@pytest.mark.asyncio
+async def test_generate_answer_successful_path(
+    mocker,
+    mock_embedding_manager,
+    mock_vector_index,
+    mock_llm_manager,
+    mock_prompt_builder, # Fixture to patch PromptBuilder
+    mock_result_formatter # Fixture to patch ResultFormatter
+):
+    """
+    Scenario 1: Successful path for generate_answer.
+    """
+    # Arrange
+    engine = RAGEngine(
+        embedding_manager=mock_embedding_manager,
+        vector_index=mock_vector_index,
+        llm_manager=mock_llm_manager
+    )
+    user_query = "What is RAG?"
+    scenario = MockScenario(llm_name="test_llm_from_scenario") # Override default
+    index_info = {"rag_k": 3} # Use specific rag_k from index_info
+
+    # Act
+    result = await engine.generate_answer(user_query, scenario, index_info)
+
+    # Assert
+    # 1. Embedding manager called
+    mock_embedding_manager.generate_embedding_async.assert_awaited_once_with(user_query)
+    
+    # 2. Vector index called
+    expected_k = index_info["rag_k"]
+    mock_vector_index.search_async.assert_awaited_once_with(
+        query_vector=await mock_embedding_manager.generate_embedding_async(user_query),
+        k=expected_k,
+        filter_expr=None # Assuming no filter for this test
+    )
+    
+    # 3. PromptBuilder called
+    # PromptBuilder instance is now mock_prompt_builder directly
+    mock_prompt_builder.build_prompt.assert_called_once()
+    # Check specific arguments of build_prompt call
+    args, kwargs = mock_prompt_builder.build_prompt.call_args
+    assert kwargs['user_query'] == user_query
+    assert kwargs['context_docs'] == await mock_vector_index.search_async() # Using the return_value
+    assert kwargs['scenario'] == scenario
+
+    # 4. LLM Manager and Adapter called
+    # get_adapter should be called with scenario.llm_name if provided, else default
+    mock_llm_manager.get_adapter.assert_called_once_with(scenario.llm_name)
+    
+    mock_adapter_instance = mock_llm_manager.get_adapter()
+    mock_adapter_instance.async_generate_response.assert_awaited_once_with(
+        "Formatted prompt string" # from mock_prompt_builder
+    )
+
+    # 5. ResultFormatter called
+    # ResultFormatter instance is now mock_result_formatter directly
+    mock_result_formatter.parse_and_format.assert_called_once_with(
+        llm_output="LLM generated answer.", # from mock_adapter
+        context_docs=await mock_vector_index.search_async(),
+        num_used_candidates=2, # from mock_prompt_builder
+        scenario=scenario
+    )
+
+    # 6. Final result
+    assert result == [{"formatted": "result"}] # from mock_result_formatter
+
+@pytest.mark.asyncio
+async def test_generate_answer_embedding_error(
+    mocker,
+    mock_embedding_manager,
+    mock_vector_index, # Still needed for RAGEngine instantiation
+    mock_llm_manager   # Still needed for RAGEngine instantiation
+):
+    """
+    Scenario 2: Embedding error.
+    - Configure embedding_manager.generate_embedding_async to raise an Exception.
+    - Assert that generate_answer raises EmbeddingError.
+    """
+    # Arrange
+    mock_embedding_manager.generate_embedding_async.side_effect = Exception("Test embedding generation failed")
+    
+    engine = RAGEngine(
+        embedding_manager=mock_embedding_manager,
+        vector_index=mock_vector_index,
+        llm_manager=mock_llm_manager
+    )
+    user_query = "Query that will cause embedding error"
+    scenario = MockScenario()
+    index_info = {}
+
+    # Act & Assert
+    with pytest.raises(EmbeddingError) as excinfo:
+        await engine.generate_answer(user_query, scenario, index_info)
+    
+    assert "Embedding generation failed" in str(excinfo.value)
+    assert "Test embedding generation failed" in str(excinfo.value.original_exception)
+
+@pytest.mark.asyncio
+async def test_generate_answer_vector_search_error(
+    mocker,
+    mock_embedding_manager, # Still needed
+    mock_vector_index,
+    mock_llm_manager # Still needed
+):
+    """
+    Scenario 3: Vector search error.
+    - Configure vector_index.search_async to raise an Exception.
+    - Assert that generate_answer raises VectorSearchError.
+    """
+    # Arrange
+    mock_vector_index.search_async.side_effect = Exception("Test vector search failed")
+    
+    engine = RAGEngine(
+        embedding_manager=mock_embedding_manager,
+        vector_index=mock_vector_index,
+        llm_manager=mock_llm_manager
+    )
+    user_query = "Query that will cause vector search error"
+    scenario = MockScenario()
+    index_info = {} # rag_k will default from scenario.rag_k
+
+    # Act & Assert
+    with pytest.raises(VectorSearchError) as excinfo:
+        await engine.generate_answer(user_query, scenario, index_info)
+    
+    assert "Vector search failed" in str(excinfo.value)
+    assert "Test vector search failed" in str(excinfo.value.original_exception)
+    # Ensure embedding was called before search
+    mock_embedding_manager.generate_embedding_async.assert_awaited_once_with(user_query)
+
+@pytest.mark.asyncio
+async def test_generate_answer_no_search_hits(
+    mocker,
+    mock_embedding_manager,
+    mock_vector_index,
+    mock_llm_manager,
+    mock_prompt_builder, # Patched PromptBuilder fixture
+    mock_result_formatter # Patched ResultFormatter fixture
+):
+    """
+    Scenario 4: No search hits.
+    - Configure vector_index.search_async to return an empty list.
+    - Assert that generate_answer returns an empty list.
+    - Assert that PromptBuilder.build_prompt and LLM methods were NOT called.
+    """
+    # Arrange
+    mock_vector_index.search_async.return_value = [] # No search hits
+    
+    engine = RAGEngine(
+        embedding_manager=mock_embedding_manager,
+        vector_index=mock_vector_index,
+        llm_manager=mock_llm_manager
+    )
+    user_query = "Query that returns no search hits"
+    scenario = MockScenario()
+    index_info = {}
+
+    # Act
+    result = await engine.generate_answer(user_query, scenario, index_info)
+
+    # Assert
+    assert result == []
+    
+    # Ensure embedding was called
+    mock_embedding_manager.generate_embedding_async.assert_awaited_once_with(user_query)
+    # Ensure vector search was called
+    mock_vector_index.search_async.assert_awaited_once()
+    
+    # Ensure PromptBuilder and LLM/ResultFormatter were NOT called
+    mock_prompt_builder.build_prompt.assert_not_called()
+    mock_llm_manager.get_adapter().async_generate_response.assert_not_called()
+    mock_result_formatter.parse_and_format.assert_not_called()
+
+@pytest.mark.asyncio
+async def test_generate_answer_prompt_too_long_error(
+    mocker,
+    mock_embedding_manager,
+    mock_vector_index,
+    mock_llm_manager,
+    mock_prompt_builder # Patched PromptBuilder fixture
+):
+    """
+    Scenario 5: PromptTooLongError during prompt building.
+    - Mock PromptBuilder.build_prompt to raise PromptTooLongError.
+    - Assert that generate_answer re-raises this error.
+    """
+    # Arrange
+    # mock_prompt_builder is the instance of the mocked PromptBuilder
+    mock_prompt_builder.build_prompt.side_effect = PromptTooLongError("Test: Prompt is too long")
+    
+    engine = RAGEngine(
+        embedding_manager=mock_embedding_manager,
+        vector_index=mock_vector_index,
+        llm_manager=mock_llm_manager
+    )
+    user_query = "Query that leads to a long prompt"
+    scenario = MockScenario()
+    index_info = {}
+
+    # Act & Assert
+    with pytest.raises(PromptTooLongError) as excinfo:
+        await engine.generate_answer(user_query, scenario, index_info)
+    
+    assert "Test: Prompt is too long" in str(excinfo.value)
+    
+    # Ensure previous steps were called
+    mock_embedding_manager.generate_embedding_async.assert_awaited_once_with(user_query)
+    mock_vector_index.search_async.assert_awaited_once()
+    mock_prompt_builder.build_prompt.assert_called_once() # build_prompt was called and raised error
+
+@pytest.mark.asyncio
+async def test_generate_answer_llm_adapter_not_found(
+    mocker,
+    mock_embedding_manager,
+    mock_vector_index,
+    mock_llm_manager,
+    mock_prompt_builder # Patched PromptBuilder fixture
+):
+    """
+    Scenario 6: LLM adapter not found.
+    - Configure llm_manager.get_adapter to return None.
+    - Assert that generate_answer raises LLMError with the message "找不到 LLM 適配器: ...".
+    """
+    # Arrange
+    mock_llm_manager.get_adapter.return_value = None # Adapter not found
+    
+    engine = RAGEngine(
+        embedding_manager=mock_embedding_manager,
+        vector_index=mock_vector_index,
+        llm_manager=mock_llm_manager
+    )
+    user_query = "Query for which LLM adapter is not found"
+    scenario = MockScenario(llm_name="non_existent_adapter")
+    index_info = {}
+
+    # Act & Assert
+    with pytest.raises(LLMError) as excinfo:
+        await engine.generate_answer(user_query, scenario, index_info)
+    
+    assert "找不到 LLM 適配器" in str(excinfo.value)
+    assert scenario.llm_name in str(excinfo.value)
+    
+    # Ensure previous steps were called
+    mock_embedding_manager.generate_embedding_async.assert_awaited_once_with(user_query)
+    mock_vector_index.search_async.assert_awaited_once()
+    mock_prompt_builder.build_prompt.assert_called_once()
+    mock_llm_manager.get_adapter.assert_called_once_with(scenario.llm_name)
+
+@pytest.mark.asyncio
+async def test_generate_answer_llm_generation_error(
+    mocker,
+    mock_embedding_manager,
+    mock_vector_index,
+    mock_llm_manager,
+    mock_prompt_builder # Patched PromptBuilder fixture
+):
+    """
+    Scenario 7: LLM generation error.
+    - Configure llm_manager.get_adapter().async_generate_response to raise an Exception.
+    - Assert that generate_answer raises LLMError with the message "LLM 生成失敗: ...".
+    """
+    # Arrange
+    mock_adapter_instance = mock_llm_manager.get_adapter() # Get the mocked adapter
+    mock_adapter_instance.async_generate_response.side_effect = Exception("Test LLM generation failed")
+    
+    engine = RAGEngine(
+        embedding_manager=mock_embedding_manager,
+        vector_index=mock_vector_index,
+        llm_manager=mock_llm_manager
+    )
+    user_query = "Query that causes LLM generation error"
+    scenario = MockScenario(llm_name="test_llm")
+    index_info = {}
+
+    # Act & Assert
+    with pytest.raises(LLMError) as excinfo:
+        await engine.generate_answer(user_query, scenario, index_info)
+    
+    assert "LLM 生成失敗" in str(excinfo.value)
+    assert "Test LLM generation failed" in str(excinfo.value.original_exception)
+    
+    # Ensure previous steps were called
+    mock_embedding_manager.generate_embedding_async.assert_awaited_once_with(user_query)
+    mock_vector_index.search_async.assert_awaited_once()
+    mock_prompt_builder.build_prompt.assert_called_once()
+    mock_llm_manager.get_adapter.assert_called_once_with(scenario.llm_name)
+    mock_adapter_instance.async_generate_response.assert_awaited_once() # Was called and raised error
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "index_info_rag_k, scenario_direction, scenario_rag_k_forward, scenario_rag_k_reverse, scenario_rag_k_fallback, expected_k",
+    [
+        (7, "forward", 5, 3, 4, 7),  # Case 1: index_info["rag_k"] takes precedence
+        (None, "forward", 5, 3, 4, 5), # Case 2: scenario.rag_k_forward used
+        (None, "reverse", 5, 3, 4, 3), # Case 3: scenario.rag_k_reverse used
+        (None, "forward", None, 3, 4, 4), # Case 4a: scenario.rag_k (fallback) used when forward is None
+        (None, "reverse", 5, None, 4, 4), # Case 4b: scenario.rag_k (fallback) used when reverse is None
+        ({}, "forward", 5, 3, 4, 5),      # Case 5: index_info is empty dict, use scenario.rag_k_forward
+        ({"other_key": 10}, "reverse", 5, 3, 4, 3) # Case 6: index_info has other keys, use scenario.rag_k_reverse
+    ],
+    ids=[
+        "index_info_rag_k",
+        "scenario_rag_k_forward",
+        "scenario_rag_k_reverse",
+        "fallback_rag_k_from_forward_none",
+        "fallback_rag_k_from_reverse_none",
+        "empty_index_info_dict",
+        "other_keys_in_index_info"
+    ]
+)
+async def test_generate_answer_rag_k_selection(
+    mocker,
+    mock_embedding_manager,
+    mock_vector_index,
+    mock_llm_manager,
+    mock_prompt_builder,
+    mock_result_formatter,
+    index_info_rag_k, scenario_direction, scenario_rag_k_forward, scenario_rag_k_reverse, scenario_rag_k_fallback, expected_k
+):
+    """
+    Scenario 8: Different rag_k sources.
+    Tests various conditions for selecting the 'k' value for vector search.
+    """
+    # Arrange
+    engine = RAGEngine(
+        embedding_manager=mock_embedding_manager,
+        vector_index=mock_vector_index,
+        llm_manager=mock_llm_manager
+    )
+    user_query = "Test query for rag_k selection"
+    
+    scenario = MockScenario(
+        direction=scenario_direction,
+        rag_k_forward=scenario_rag_k_forward,
+        rag_k_reverse=scenario_rag_k_reverse,
+        rag_k=scenario_rag_k_fallback,
+        llm_name="test_llm" # Ensure an LLM name is set
+    )
+    
+    if isinstance(index_info_rag_k, dict): # For cases like empty_index_info_dict
+        index_info = index_info_rag_k
+    elif index_info_rag_k is None:
+        index_info = {} # Default to empty if None for rag_k, to simulate absence
+    else:
+        index_info = {"rag_k": index_info_rag_k}
+
+
+    # Act
+    await engine.generate_answer(user_query, scenario, index_info)
+
+    # Assert
+    # Main assertion: vector_index.search_async called with the correct k
+    mock_vector_index.search_async.assert_awaited_once_with(
+        query_vector=await mock_embedding_manager.generate_embedding_async(user_query),
+        k=expected_k,
+        filter_expr=None # Assuming no filter for these test cases
+    )
+    
+    # Ensure other parts of the pipeline were called to confirm it's a successful path otherwise
+    mock_embedding_manager.generate_embedding_async.assert_awaited_once_with(user_query)
+    mock_prompt_builder.build_prompt.assert_called_once()
+    mock_llm_manager.get_adapter().async_generate_response.assert_awaited_once()
+    mock_result_formatter.parse_and_format.assert_called_once()
+
+# Tests for generate_answer_sync
+
+def test_generate_answer_sync_successful_path(
+    mocker,
+    mock_embedding_manager, # Needed for engine instantiation
+    mock_vector_index,      # Needed for engine instantiation
+    mock_llm_manager        # Needed for engine instantiation
+):
+    """
+    Scenario 1 (sync): Successful path for generate_answer_sync.
+    - Mock RAGEngine.generate_answer (async) to return a specific result.
+    - Call generate_answer_sync and assert it returns the mocked result.
+    - Assert generate_answer (async) was called with correct arguments.
+    """
+    # Arrange
+    engine = RAGEngine(
+        embedding_manager=mock_embedding_manager,
+        vector_index=mock_vector_index,
+        llm_manager=mock_llm_manager
+    )
+    user_query = "Sync test query"
+    scenario = MockScenario()
+    index_info = {"sync_test_key": "value"}
+    expected_result = [{"sync_result": "success"}]
+
+    # Mock the async generate_answer method ON THE INSTANCE
+    mocked_async_generate = AsyncMock(return_value=expected_result)
+    mocker.patch.object(engine, 'generate_answer', new=mocked_async_generate)
+
+    # Act
+    result = engine.generate_answer_sync(user_query, scenario, index_info)
+
+    # Assert
+    assert result == expected_result
+    mocked_async_generate.assert_awaited_once_with(user_query, scenario, index_info)
+
+
+def test_generate_answer_sync_exception_propagation(
+    mocker,
+    mock_embedding_manager,
+    mock_vector_index,
+    mock_llm_manager
+):
+    """
+    Scenario 2 (sync): Exception during async execution.
+    - Mock RAGEngine.generate_answer (async) to raise an EmbeddingError.
+    - Call generate_answer_sync and assert it re-raises the EmbeddingError.
+    """
+    # Arrange
+    engine = RAGEngine(
+        embedding_manager=mock_embedding_manager,
+        vector_index=mock_vector_index,
+        llm_manager=mock_llm_manager
+    )
+    user_query = "Sync query causing error"
+    scenario = MockScenario()
+    index_info = {}
+    
+    # Mock the async generate_answer method to raise an error
+    mocked_async_generate = AsyncMock(side_effect=EmbeddingError("Async embedding failed"))
+    mocker.patch.object(engine, 'generate_answer', new=mocked_async_generate)
+
+    # Act & Assert
+    with pytest.raises(EmbeddingError) as excinfo:
+        engine.generate_answer_sync(user_query, scenario, index_info)
+    
+    assert "Async embedding failed" in str(excinfo.value)
+    mocked_async_generate.assert_awaited_once_with(user_query, scenario, index_info)
+
+# End of tests for RAGEngine

--- a/tests/config/test_settings.py
+++ b/tests/config/test_settings.py
@@ -1,0 +1,266 @@
+import pytest
+import os
+import yaml
+import importlib
+from unittest.mock import mock_open, patch
+
+# Import the specific classes and functions to be tested
+from src.config.settings import (
+    APIKeysConfig,
+    ScenarioConfig,
+    Settings,
+    ConfigManager,
+    get_config_manager,
+    PROJECT_ROOT # Used for path resolution tests
+)
+
+# --- Fixtures ---
+
+@pytest.fixture(autouse=True)
+def clear_get_config_manager_cache():
+    """Automatically clear lru_cache for get_config_manager before each test."""
+    get_config_manager.cache_clear()
+    yield
+
+@pytest.fixture
+def mock_project_root(mocker):
+    """Mocks PROJECT_ROOT for consistent path testing."""
+    test_root = "/test_project_root"
+    mocker.patch('src.config.settings.PROJECT_ROOT', test_root)
+    return test_root
+
+# --- Test Pydantic Models Directly ---
+
+class TestAPIKeysConfig:
+    def test_api_keys_config_with_env_var(self, mocker):
+        """With OPENAI_API_KEY="env_openai_key" mocked, assert cfg.openai."""
+        mocker.patch.dict(os.environ, {"OPENAI_API_KEY": "env_openai_key"}, clear=True)
+        cfg = APIKeysConfig()
+        assert cfg.openai == "env_openai_key"
+
+    def test_api_keys_config_without_env_var(self, mocker):
+        """Without env var, assert cfg.openai == "" (default)."""
+        mocker.patch.dict(os.environ, {}, clear=True) # Ensure env var is not set
+        cfg = APIKeysConfig()
+        assert cfg.openai == ""
+
+class TestScenarioConfigPathResolution:
+    def test_scenario_config_path_resolution(self, mock_project_root):
+        """Test path resolution with mocked PROJECT_ROOT."""
+        scfg = ScenarioConfig(
+            reference_json="data/ref.json",
+            input_json="data/in.json",
+            output_json="out/res.json"
+        )
+        expected_ref = os.path.join(mock_project_root, "data/ref.json")
+        expected_in = os.path.join(mock_project_root, "data/in.json")
+        expected_out = os.path.join(mock_project_root, "out/res.json")
+        
+        assert scfg.reference_json == expected_ref
+        assert scfg.input_json == expected_in
+        assert scfg.output_json == expected_out
+
+    def test_scenario_config_with_none_paths(self, mock_project_root):
+        """Test ScenarioConfig with None paths."""
+        scfg = ScenarioConfig(reference_json=None, input_json=None, output_json=None)
+        assert scfg.reference_json is None
+        assert scfg.input_json is None
+        assert scfg.output_json is None
+
+# --- Test Settings Class (Pydantic BaseSettings behavior) ---
+
+class TestSettingsClass:
+    def test_settings_defaults_only(self, mocker):
+        """Defaults only: Clear relevant env vars. Check a few default values."""
+        mocker.patch.dict(os.environ, {}, clear=True)
+        # Reload settings module to re-evaluate Settings with cleared env vars
+        importlib.reload(src.config.settings)
+        s = src.config.settings.Settings()
+        
+        assert s.llm.model == "gpt-4-1106-preview" # Example default
+        assert s.vector_db.url == "http://localhost:6333" # Example default
+        assert s.system.is_debug is False # Example default
+
+    def test_settings_env_vars_override_defaults(self, mocker):
+        """Env vars override defaults."""
+        mock_env_vars = {
+            "OPENAI_API_KEY": "env_key",
+            "QDRANT_URL": "env_q_url",
+            "LLM_MODEL": "env_llm",
+            "SYSTEM_IS_DEBUG": "true", # Pydantic converts "true" to True for bool
+            "SCENARIO_REFERENCE_JSON": "test_ref.json" # Example for nested model
+        }
+        mocker.patch.dict(os.environ, mock_env_vars, clear=True)
+        
+        # Reload settings module to ensure Settings picks up new env vars
+        importlib.reload(src.config.settings)
+        s = src.config.settings.Settings()
+        
+        assert s.api_keys.openai == "env_key"
+        assert s.vector_db.url == "env_q_url"
+        assert s.llm.model == "env_llm"
+        assert s.system.is_debug is True
+        # For nested models, check if the environment variable for a sub-field is picked up
+        # Note: Pydantic v2 settings_nested_delimiter is '__' by default.
+        # The prompt used SYSTEM__IS_DEBUG which is fine.
+        # For SCENARIO_REFERENCE_JSON, it would be SCENARIO__REFERENCE_JSON if settings_nested_delimiter was used.
+        # However, pydantic also allows direct env var names if they match field names.
+        # Let's test a field that would be directly set by an env var if not nested.
+        # The current Settings structure does not directly expose SCENARIO_REFERENCE_JSON at top level.
+        # It's settings.scenario.reference_json. Pydantic handles this via nested model instantiation.
+        # So, we test if the ScenarioConfig within Settings got its value.
+        # This requires SCENARIO_REFERENCE_JSON to be correctly interpreted by ScenarioConfig.
+        # For BaseSettings, env vars for sub-models are typically prefixed, e.g., RAG_CORE_SCENARIO_REFERENCE_JSON
+        # if RAG_CORE_ is the prefix for Settings.
+        # Let's assume no prefix for this test as per prompt structure.
+        # The prompt seems to imply that SYSTEM_IS_DEBUG works, so direct field names for submodels might be expected.
+        # This part of pydantic behavior can be tricky. Let's assume direct mapping for sub-fields if unprefixed.
+        # Actually, for nested models, Pydantic v1 used `parent_field_name__child_field_name`.
+        # Pydantic v2 uses `model_config = SettingsConfigDict(env_nested_delimiter='__')` by default.
+        # So, SCENARIO__REFERENCE_JSON would be the way.
+        # The example `SYSTEM_IS_DEBUG` implies the structure `system: SystemConfig`.
+        # The prompt's `LLM_MODEL` implies `llm: LLMConfig`.
+        # Let's add an env var for a ScenarioConfig field to test this.
+        mocker.patch.dict(os.environ, {"SCENARIO_REFERENCE_JSON": "env_scenario_ref.json"}, clear=False) # Add to existing
+        importlib.reload(src.config.settings) # Reload again after adding new var
+        s_reloaded = src.config.settings.Settings()
+        assert s_reloaded.scenario.reference_json.endswith("env_scenario_ref.json") #endswith due to path resolution
+
+
+# --- Test ConfigManager Instance and _load_settings ---
+
+class TestConfigManager:
+
+    @pytest.fixture(autouse=True)
+    def setup_mocks_for_config_manager(self, mocker):
+        """Setup common mocks for ConfigManager tests."""
+        self.mock_os_path_exists = mocker.patch('src.config.settings.os.path.exists')
+        self.mock_open_file = mocker.patch('builtins.open', new_callable=mock_open)
+        self.mock_yaml_safe_load = mocker.patch('src.config.settings.yaml.safe_load')
+
+    def test_no_settings_base_yml(self, mocker):
+        """No settings.base.yml: Load from env vars and defaults."""
+        self.mock_os_path_exists.return_value = False # settings.base.yml does not exist
+        mocker.patch.dict(os.environ, {"LLM_MODEL": "env_only_model"}, clear=True)
+        
+        importlib.reload(src.config.settings) # Reload to re-evaluate ConfigManager global state potentially
+        manager = src.config.settings.ConfigManager() # Test with a fresh instance
+        
+        assert manager.settings.llm.model == "env_only_model"
+        assert manager.settings.vector_db.vector_size == 768 # Default value
+
+    def test_settings_base_yml_loads_and_overrides(self, mocker, mock_project_root):
+        """settings.base.yml loads; env vars take precedence for non-YAML fields or if YAML values are Pydantic defaults."""
+        self.mock_os_path_exists.return_value = True # settings.base.yml exists
+        yaml_content = {
+            "llm": {"model": "yaml_model"}, 
+            "vector_db": {"collection": "yaml_coll"}
+            # vector_db.url is NOT in YAML, so env var should take effect
+        }
+        self.mock_yaml_safe_load.return_value = yaml_content
+        self.mock_open_file.return_value.read.return_value = yaml.dump(yaml_content)
+
+
+        # Env vars: LLM_MODEL should be overridden by YAML if YAML is not a default.
+        # QDRANT_URL should take effect as it's not in YAML.
+        # Pydantic's behavior: Env vars have higher precedence than values from YAML file IF the YAML value is a default.
+        # If YAML specifies a non-default value, it takes precedence over env vars unless the env var is for a different field.
+        # The prompt implies YAML takes precedence for fields it defines.
+        # Let's test based on the prompt's interpretation: YAML defined fields override env vars.
+        mocker.patch.dict(os.environ, {
+            "LLM_MODEL": "env_model_overridden_by_yaml", 
+            "QDRANT_URL": "env_q_url_takes_effect"
+        }, clear=True)
+        
+        importlib.reload(src.config.settings)
+        manager = src.config.settings.ConfigManager()
+
+        assert manager.settings.llm.model == "yaml_model" # YAML value for 'model'
+        assert manager.settings.vector_db.collection == "yaml_coll" # YAML value for 'collection'
+        assert manager.settings.vector_db.url == "env_q_url_takes_effect" # Env var, as 'url' not in YAML
+
+
+    def test_settings_base_yml_is_empty(self, mocker):
+        """settings.base.yml is empty: Load from env vars and defaults."""
+        self.mock_os_path_exists.return_value = True
+        self.mock_yaml_safe_load.return_value = {} # Empty YAML
+        self.mock_open_file.return_value.read.return_value = yaml.dump({})
+
+        mocker.patch.dict(os.environ, {"LLM_MODEL": "env_model_takes_effect_empty_yaml"}, clear=True)
+        
+        importlib.reload(src.config.settings)
+        manager = src.config.settings.ConfigManager()
+        
+        assert manager.settings.llm.model == "env_model_takes_effect_empty_yaml"
+        assert manager.settings.vector_db.port == 6333 # Default
+
+    def test_get_scenario_config(self, mocker):
+        """Test ConfigManager.get_scenario_config."""
+        # Setup ConfigManager with some scenario data in its settings
+        self.mock_os_path_exists.return_value = False # No YAML file
+        mocker.patch.dict(os.environ, {
+            "SCENARIO_REFERENCE_JSON": "env_ref.json",
+            "SCENARIO_INPUT_JSON": "env_in.json",
+            "SCENARIO_OUTPUT_JSON": "env_out.json"
+        }, clear=True)
+        
+        importlib.reload(src.config.settings)
+        manager = src.config.settings.ConfigManager()
+        
+        # Ensure paths are resolved in the scenario config loaded into settings
+        expected_scenario_dict = src.config.settings.ScenarioConfig(
+            reference_json="env_ref.json",
+            input_json="env_in.json",
+            output_json="env_out.json"
+        ).model_dump() # Use model_dump for Pydantic v2
+
+        sc_dict_from_manager = manager.get_scenario_config()
+        
+        # We need to compare based on the values after path resolution
+        # The ScenarioConfig in manager.settings will have resolved paths.
+        assert sc_dict_from_manager['reference_json'].endswith("env_ref.json")
+        assert sc_dict_from_manager['input_json'].endswith("env_in.json")
+        assert sc_dict_from_manager['output_json'].endswith("env_out.json")
+        
+        # Check against manager.settings.scenario directly
+        assert sc_dict_from_manager == manager.settings.scenario.model_dump()
+
+
+# --- Test get_config_manager Singleton Behavior ---
+
+def test_get_config_manager_singleton(mocker):
+    """Test get_config_manager singleton behavior."""
+    # Mock os.path.exists to False to simplify ConfigManager instantiation
+    mocker.patch('src.config.settings.os.path.exists', return_value=False)
+    mocker.patch.dict(os.environ, {}, clear=True)
+
+    # Must reload the module if we want to test the global config_manager instance behavior
+    # or the caching of get_config_manager across different mock setups IF get_config_manager
+    # itself depends on module-level state that mocks would change.
+    # For lru_cache, clearing it (done by fixture) is key.
+    
+    importlib.reload(src.config.settings) # Ensure a fresh start for the module context
+    manager1 = src.config.settings.get_config_manager()
+    
+    importlib.reload(src.config.settings) # Simulate a different part of code importing/calling
+    manager2 = src.config.settings.get_config_manager() # Should get from cache if not reloaded
+                                                        # but reload + cache_clear ensures clean test
+
+    # The key is that get_config_manager is cached. Reloading the module
+    # itself gives a new function object if we don't re-import carefully.
+    # The autouse fixture clear_get_config_manager_cache handles the cache clearing.
+    
+    # Re-import get_config_manager after reload if module was reloaded
+    # For this test, we want to see if two calls to THE SAME get_config_manager function object
+    # return the same ConfigManager instance.
+    
+    # Let's ensure we're calling the same function object for cache to work as expected in test
+    current_get_config_manager = src.config.settings.get_config_manager
+    current_get_config_manager.cache_clear() # Clear again just in case
+
+    manager1 = current_get_config_manager()
+    manager2 = current_get_config_manager()
+    
+    assert manager1 is manager2
+
+# End of test file

--- a/tests/domain/test_schema_checker.py
+++ b/tests/domain/test_schema_checker.py
@@ -1,0 +1,287 @@
+import pytest
+from rag_core.domain.schema_checker import DataStructureChecker, DataSchemaError
+
+@pytest.fixture
+def checker():
+    return DataStructureChecker()
+
+# Helper function to create valid nested data
+def create_valid_data(levels=5, sid_prefix="s", text_prefix="text", add_extra_keys=False):
+    data = {}
+    current_level_list = [{"sid": f"{sid_prefix}_root", "text": f"{text_prefix}_root"}]
+    if add_extra_keys:
+        current_level_list[0]["extra_key_root"] = "extra_value_root"
+
+    if levels == 0: # For is_valid_level_structure, which might get just the list part
+        return current_level_list
+
+    data["level1"] = current_level_list
+    
+    for i in range(1, levels): # Starts from level 2 effectively
+        next_level_list = [{"sid": f"{sid_prefix}_l{i+1}_{j}", "text": f"{text_prefix}_l{i+1}_{j}"} for j in range(1)]
+        if add_extra_keys:
+            next_level_list[0][f"extra_key_l{i+1}"] = f"extra_value_l{i+1}"
+            
+        # Attach to all items in current_level_list
+        for item in current_level_list:
+            item[f"level{i+1}"] = next_level_list # Next level key, e.g. level2, level3
+        
+        current_level_list = next_level_list # Move to the newly created list for the next iteration
+        if i + 1 == levels: # If the next level to be populated is the last specified level
+            break
+    return data
+
+class TestDataStructureCheckerValidate:
+
+    def test_validate_valid_structure_deepest_level(self, checker):
+        """Scenario 1: Valid structure (deepest level up to level5)."""
+        data = create_valid_data(levels=5)
+        try:
+            checker.validate(data, mode="default", max_depth=5) 
+        except DataSchemaError as e:
+            pytest.fail(f"Validation failed unexpectedly: {e.details}")
+
+    def test_validate_valid_structure_shallower_level(self, checker):
+        """Scenario 2: Valid structure (shallower level, e.g., up to level2)."""
+        data = create_valid_data(levels=2)
+        try:
+            checker.validate(data, mode="default", max_depth=2)
+        except DataSchemaError as e:
+            pytest.fail(f"Validation failed unexpectedly: {e.details}")
+            
+    def test_validate_valid_structure_with_extra_keys(self, checker):
+        """Test valid structure with extra keys at various levels."""
+        data = create_valid_data(levels=3, add_extra_keys=True)
+        try:
+            checker.validate(data, mode="default", max_depth=3)
+        except DataSchemaError as e:
+            pytest.fail(f"Validation with extra keys failed unexpectedly: {e.details}")
+
+
+    def test_validate_invalid_top_level_not_a_dict(self, checker):
+        """Scenario 3: Invalid: Top level not a dict."""
+        data = "not a dictionary"
+        with pytest.raises(DataSchemaError) as excinfo:
+            checker.validate(data, mode="default")
+        assert "Top-level data is not a dict at path 'root'" in excinfo.value.details[0]
+
+    def test_validate_invalid_missing_level1_key(self, checker):
+        """Scenario 4: Invalid: Missing level1 key."""
+        data = {"level2": []} 
+        with pytest.raises(DataSchemaError) as excinfo:
+            checker.validate(data, mode="default")
+        assert "Missing key 'level1' at path 'root'" in excinfo.value.details[0]
+        
+    @pytest.mark.parametrize("level_key_to_make_invalid, path_segment", [
+        ("level1", "root"),
+        ("level2", "root/level1[0]"),
+        ("level3", "root/level1[0]/level2[0]")
+    ])
+    def test_validate_invalid_level_x_not_a_list(self, checker, level_key_to_make_invalid, path_segment):
+        """Scenario 5: Invalid: levelX is not a list."""
+        data = create_valid_data(levels=5) # Create a valid structure first
+        
+        # Introduce the error
+        if level_key_to_make_invalid == "level1":
+            data["level1"] = "not a list"
+        elif level_key_to_make_invalid == "level2":
+            data["level1"][0]["level2"] = "not a list"
+        elif level_key_to_make_invalid == "level3":
+            data["level1"][0]["level2"][0]["level3"] = "not a list"
+            
+        with pytest.raises(DataSchemaError) as excinfo:
+            checker.validate(data, mode="default")
+        
+        assert f"'{level_key_to_make_invalid}' should be a list at path '{path_segment}'" in excinfo.value.details[0]
+
+
+    @pytest.mark.parametrize("level_to_corrupt, expected_path_segment", [
+        (1, "root/level1[0]"),
+        (2, "root/level1[0]/level2[0]"),
+        (3, "root/level1[0]/level2[0]/level3[0]")
+    ])
+    def test_validate_invalid_item_in_level_x_list_not_a_dict(self, checker, level_to_corrupt, expected_path_segment):
+        """Scenario 6: Invalid: Item in levelX list is not a dict."""
+        data = create_valid_data(levels=level_to_corrupt) # Create data up to the point of corruption
+        
+        # Corrupt the data
+        if level_to_corrupt == 1:
+            data["level1"] = ["not a dict"]
+        elif level_to_corrupt == 2:
+            data["level1"][0]["level2"] = ["not a dict"]
+        elif level_to_corrupt == 3:
+            data["level1"][0]["level2"][0]["level3"] = ["not a dict"]
+            
+        with pytest.raises(DataSchemaError) as excinfo:
+            checker.validate(data, mode="default", max_depth=level_to_corrupt)
+        assert f"Item at '{expected_path_segment}' is not a dict" in excinfo.value.details[0]
+
+
+    @pytest.mark.parametrize("item_data_modifier, expected_msg_part, path_segment_suffix", [
+        (lambda item: item.pop("sid"), "Missing or invalid 'sid'", ""), # Missing sid
+        (lambda item: item.pop("text"), "Missing or invalid 'text'", ""), # Missing text
+        (lambda item: item.update({"sid": 123}), "Missing or invalid 'sid'", ""), # sid not a string
+        (lambda item: item.update({"text": 123}), "Missing or invalid 'text'", ""), # text not a string
+    ])
+    def test_validate_invalid_missing_or_invalid_sid_text_at_level1(self, checker, item_data_modifier, expected_msg_part, path_segment_suffix):
+        """Scenario 7a: Invalid sid/text at level1."""
+        data = {"level1": [{"sid": "s1", "text": "t1"}]}
+        item_data_modifier(data["level1"][0]) # Modify the item
+
+        with pytest.raises(DataSchemaError) as excinfo:
+            checker.validate(data, mode="default")
+        assert f"{expected_msg_part} at 'root/level1[0]{path_segment_suffix}'" in excinfo.value.details[0]
+
+    def test_validate_invalid_sid_text_at_nested_level2(self, checker):
+        """Scenario 7b: Invalid sid/text at level2."""
+        data = create_valid_data(levels=2)
+        data["level1"][0]["level2"][0]["sid"] = 123 # Invalid sid type at level2 item 0
+        
+        with pytest.raises(DataSchemaError) as excinfo:
+            checker.validate(data, mode="default", max_depth=2)
+        assert "Missing or invalid 'sid' at 'root/level1[0]/level2[0]'" in excinfo.value.details[0]
+
+
+    def test_validate_valid_structure_with_max_depth_param(self, checker):
+        """Scenario 8a: Data valid to level3. Call validate with max_depth=2. Assert no error."""
+        data = create_valid_data(levels=3)
+        try:
+            checker.validate(data, mode="default", max_depth=2)
+        except DataSchemaError as e:
+            pytest.fail(f"Validation failed unexpectedly with max_depth=2: {e.details}")
+
+    def test_validate_error_at_level3_max_depth_2_no_error(self, checker):
+        """Scenario 8b: Data has error at level3. Call validate with max_depth=2. Assert no error."""
+        data = create_valid_data(levels=2) # Valid up to L2 items
+        data["level1"][0]["level2"][0]["level3"] = "not a list" # Error at level 3 structure
+        try:
+            checker.validate(data, mode="default", max_depth=2) # max_depth stops before L3
+        except DataSchemaError as e:
+            pytest.fail(f"Validation failed unexpectedly with max_depth=2 and error at level3: {e.details}")
+
+    def test_validate_error_at_level3_max_depth_3_raises_error(self, checker):
+        """Scenario 8c: Data has error at level3. Call validate with max_depth=3. Assert DataSchemaError."""
+        data = create_valid_data(levels=2) 
+        data["level1"][0]["level2"][0]["level3"] = "this is not a list" 
+        
+        with pytest.raises(DataSchemaError) as excinfo:
+            checker.validate(data, mode="default", max_depth=3)
+        assert "'level3' should be a list at path 'root/level1[0]/level2[0]'" in excinfo.value.details[0]
+
+
+    def test_validate_multiple_errors(self, checker):
+        """Scenario 9: Multiple errors. Assert DataSchemaError and check details."""
+        data = {
+            "level1": [
+                {"sid": 123, "text": "text1"},      # Error 1: sid not string
+                {"text": "text2"},                  # Error 2: missing sid
+                {"sid": "s3", "level2": "notalist"} # Error 3: missing text, Error 4: level2 not list
+            ]
+        }
+        with pytest.raises(DataSchemaError) as excinfo:
+            checker.validate(data, mode="default", max_depth=2) # max_depth=2 to catch level2 error
+        
+        details_str = "; ".join(excinfo.value.details)
+        assert "Missing or invalid 'sid' at 'root/level1[0]'" in details_str
+        assert "Missing or invalid 'sid' at 'root/level1[1]'" in details_str
+        assert "Missing or invalid 'text' at 'root/level1[2]'" in details_str # This error
+        assert "'level2' should be a list at path 'root/level1[2]'" in details_str # This error path for level2
+        # The number of errors might be tricky due to cascading, let's check for key messages
+        assert len(excinfo.value.details) == 4
+
+
+class TestDataStructureCheckerIsValidLevelStructure:
+    # is_valid_level_structure uses self.validate internally.
+    # The behavior of validate is already extensively tested above.
+    # These tests will focus on the boolean return value of is_valid_level_structure.
+
+    def test_is_valid_level_structure_true_for_valid_data(self, checker):
+        data = create_valid_data(levels=2)
+        assert checker.is_valid_level_structure(data) == True
+
+    def test_is_valid_level_structure_false_for_invalid_data(self, checker):
+        data = {"level1": "not a list"}
+        assert checker.is_valid_level_structure(data) == False
+        
+    def test_is_valid_level_structure_empty_dict(self, checker):
+        # validate will raise "Missing key 'level1'"
+        assert checker.is_valid_level_structure({}) == False
+
+    def test_is_valid_level_structure_top_level_not_dict(self, checker):
+        assert checker.is_valid_level_structure("string") == False
+        
+    def test_is_valid_level_structure_respects_max_depth_via_validate(self, checker):
+        """Test that is_valid_level_structure implicitly uses default max_depth of validate (5)."""
+        # This test assumes `validate` uses its default `max_depth` if not specified by `is_valid_level_structure`
+        # The current `is_valid_level_structure` does not pass `max_depth`.
+        # It calls `self.validate(data, mode="")` which implies `max_depth` defaults to 5.
+        data_valid_to_l2_error_at_l3 = create_valid_data(levels=2)
+        data_valid_to_l2_error_at_l3["level1"][0]["level2"][0]["level3"] = "error here"
+
+        # If validate is called with max_depth=2, it should pass.
+        # If validate is called with max_depth=3 (or default 5), it should fail.
+        # Since is_valid_level_structure doesn't set max_depth, validate's default is used.
+        
+        # To test this properly, we'd need to know if `validate`'s default `max_depth` is used.
+        # The current `validate` signature `max_depth: int = 5`.
+        # So, errors beyond level 5 would be ignored, but errors at level 3 (like above) would be caught.
+        assert checker.is_valid_level_structure(data_valid_to_l2_error_at_l3) == False
+
+
+class TestDataSchemaError:
+    def test_data_schema_error_instantiation_and_str(self):
+        """Test DataSchemaError instantiation and string representation."""
+        details = ["Error detail 1", "Another error here"]
+        error = DataSchemaError(details=details)
+        
+        error_str = str(error)
+        # The base class __init__ is "Data schema validation failed"
+        # The __str__ method is "DataSchemaError: {'; '.join(self.details)}"
+        assert "DataSchemaError: Error detail 1; Another error here" == error_str
+        assert error.details == details
+
+    def test_data_schema_error_single_detail(self):
+        details = ["A single specific error occurred"]
+        error = DataSchemaError(details=details)
+        assert "DataSchemaError: A single specific error occurred" == str(error)
+        assert error.details == details
+
+    def test_data_schema_error_empty_details(self):
+        # While the type hint is List[str], it could technically be called with an empty list.
+        details = []
+        error = DataSchemaError(details=details)
+        assert "DataSchemaError: " == str(error) # Joins to empty string
+        assert error.details == []
+
+    def test_data_schema_error_is_exception(self):
+        error = DataSchemaError(details=["test"])
+        assert isinstance(error, Exception)
+
+# Final check for any missed scenarios based on prompt.
+# The prompt's "is_valid_level_structure" scenarios were more about basic list of dicts,
+# but the actual implementation uses the full validate method.
+# The tests for validate are quite exhaustive and cover the nested structure.
+# TestDataStructureCheckerIsValidLevelStructure has been updated to reflect its actual usage of validate.The tests in `tests/domain/test_schema_checker.py` have been updated.
+
+Key changes:
+1.  **`TestDataSchemaError`**:
+    *   Modified tests to align with the actual `DataSchemaError` constructor which only takes `details: List[str]`.
+    *   Updated assertions to match the `__str__` output: `f"DataSchemaError: {'; '.join(self.details)}"`.
+    *   Removed assertions related to `path` or custom main messages in the error object as they are not supported by the current `DataSchemaError` implementation.
+
+2.  **`TestDataStructureCheckerValidate`**:
+    *   Adjusted `create_valid_data` helper to correctly build paths for deeper levels and allow testing with extra keys (which should be ignored by the validator).
+    *   Refined path assertions in error messages to match the `root/levelX[index]/levelY[index]` format used by the `_recurse` method in `DataStructureChecker`. For example, `level1[0]` became `root/level1[0]`.
+    *   Ensured `max_depth` parameters in tests correctly reflect the levels being tested and the expected behavior.
+    *   Added a test case for valid data that includes extra, non-schema keys, which should still pass validation.
+    *   Improved clarity in parameterized tests for invalid `sid`/`text` and items not being lists/dicts at various levels.
+    *   Corrected the multi-error test (`test_validate_multiple_errors`) to reflect actual error messages and paths, and ensure `max_depth` is set appropriately to catch errors at nested levels if intended for that specific test. The assertion for the number of errors is now `len(excinfo.value.details)` as `excinfo.value.errors` does not exist.
+
+3.  **`TestDataStructureCheckerIsValidLevelStructure`**:
+    *   The original prompt implied `is_valid_level_structure` might have simpler, non-recursive logic. However, the provided source code shows it directly calls `self.validate(data, mode="")`.
+    *   The tests for `is_valid_level_structure` have been updated to reflect this, primarily checking its boolean return type based on the success or failure of the internal `validate` call (which is already extensively tested).
+    *   Added a test to clarify that `is_valid_level_structure` uses the default `max_depth` of the `validate` method.
+
+The updated test suite now more accurately reflects the behavior and error reporting of the provided `DataStructureChecker` and `DataSchemaError` implementations.
+
+I will now submit the report.

--- a/tests/infrastructure/llm/test_base_adapter.py
+++ b/tests/infrastructure/llm/test_base_adapter.py
@@ -1,0 +1,101 @@
+import pytest
+from unittest.mock import MagicMock, patch
+from rag_core.infrastructure.llm.base_adapter import LLMAdapter
+
+class TestLLMAdapterInit:
+    def test_init_sets_model(self, mocker):
+        """Test that LLMAdapter.__init__ correctly sets the model."""
+        mock_model = mocker.Mock()
+        adapter = LLMAdapter(model=mock_model)
+        assert adapter.model == mock_model
+
+class TestLLMAdapterAbstractMethods:
+    @pytest.fixture
+    def adapter_instance(self):
+        # LLMAdapter can be instantiated without a model for these tests,
+        # as it's not used by the abstract methods before they raise NotImplementedError.
+        # If __init__ required a model strictly, we'd pass mocker.Mock() here.
+        return LLMAdapter(model=MagicMock())
+
+
+    def test_generate_response_raises_not_implemented(self, adapter_instance):
+        """Test that generate_response raises NotImplementedError."""
+        with pytest.raises(NotImplementedError):
+            adapter_instance.generate_response("test prompt")
+
+    def test_stream_response_raises_not_implemented(self, adapter_instance):
+        """Test that stream_response raises NotImplementedError."""
+        with pytest.raises(NotImplementedError):
+            # Attempt to get an iterator (which stream_response should be)
+            # and then call next() or list() on it.
+            # Directly calling might not execute up to the yield if it's a generator.
+            # However, if it's truly abstract, the call itself should fail.
+            list(adapter_instance.stream_response("test prompt"))
+
+
+    @pytest.mark.asyncio
+    async def test_async_generate_response_raises_not_implemented(self, adapter_instance):
+        """Test that async_generate_response raises NotImplementedError."""
+        with pytest.raises(NotImplementedError):
+            await adapter_instance.async_generate_response("test prompt")
+
+    @pytest.mark.asyncio
+    async def test_async_stream_response_raises_not_implemented(self, adapter_instance):
+        """Test that async_stream_response raises NotImplementedError."""
+        with pytest.raises(NotImplementedError):
+            # Similar to stream_response, attempt to iterate
+            async for _ in adapter_instance.async_stream_response("test prompt"):
+                pass # Should not reach here
+
+
+class TestLLMAdapterHandleError:
+    def test_handle_error_logs_correctly(self, mocker):
+        """Test that handle_error logs the error with the correct details."""
+        mock_log_error = mocker.patch('rag_core.infrastructure.llm.base_adapter.log_wrapper.error')
+        adapter = LLMAdapter(model=MagicMock())
+        test_exception = Exception("Test error details")
+        
+        adapter.handle_error(test_exception)
+        
+        mock_log_error.assert_called_once_with(
+            "BaseAdapter",  # Class name from the method
+            "handle_error", # Method name
+            "LLMAdapter Error: Test error details" # Formatted message
+        )
+
+
+class TestLLMAdapterGenerateResponseSync:
+    @pytest.fixture
+    def adapter_instance(self, mocker):
+        # For these tests, the model itself is not directly used by generate_response_sync,
+        # but the generate_response method (which would use it) is mocked.
+        return LLMAdapter(model=mocker.Mock())
+
+    def test_generate_response_sync_successful_path(self, mocker, adapter_instance):
+        """Scenario 4a: generate_response succeeds."""
+        expected_response = "successful response"
+        mocker.patch.object(adapter_instance, 'generate_response', return_value=expected_response)
+        
+        result = adapter_instance.generate_response_sync("test prompt")
+        
+        assert result == expected_response
+        adapter_instance.generate_response.assert_called_once_with("test prompt")
+
+    def test_generate_response_sync_exception_path(self, mocker, adapter_instance):
+        """Scenario 4b: generate_response raises an exception."""
+        original_exception = ValueError("LLM failure")
+        mocker.patch.object(adapter_instance, 'generate_response', side_effect=original_exception)
+        mock_log_error = mocker.patch('rag_core.infrastructure.llm.base_adapter.log_wrapper.error')
+        
+        with pytest.raises(ValueError, match="LLM failure") as excinfo:
+            adapter_instance.generate_response_sync("test prompt")
+        
+        assert excinfo.value == original_exception
+        adapter_instance.generate_response.assert_called_once_with("test prompt")
+        mock_log_error.assert_called_once_with(
+            "BaseAdapter",
+            "generate_response_sync",
+            "LLMAdapter Error: LLM failure"
+        )
+
+# End of test file

--- a/tests/infrastructure/llm/test_llm_manager.py
+++ b/tests/infrastructure/llm/test_llm_manager.py
@@ -1,0 +1,94 @@
+import pytest
+from unittest.mock import MagicMock # For spec if needed, but mocker.Mock is fine
+
+from rag_core.infrastructure.llm.llm_manager import LLMManager
+from rag_core.infrastructure.llm.base_adapter import LLMAdapter # For spec
+
+class TestLLMManagerInit:
+    def test_init_default_state(self):
+        """
+        Test LLMManager instantiation.
+        Asserts that manager.adapters is an empty dictionary and 
+        manager.default_adapter_name is an empty string.
+        """
+        manager = LLMManager()
+        assert manager.adapters == {}
+        assert manager.default_adapter_name == ""
+
+class TestLLMManagerRegisterAdapter:
+    def test_register_adapter_adds_to_adapters_dict(self, mocker):
+        """
+        Test register_adapter.
+        Asserts that the adapter is correctly added to the manager.adapters dictionary.
+        """
+        manager = LLMManager()
+        mock_adapter = mocker.Mock(spec=LLMAdapter)
+        
+        manager.register_adapter("test_adapter", mock_adapter)
+        
+        assert "test_adapter" in manager.adapters
+        assert manager.adapters["test_adapter"] is mock_adapter
+
+class TestLLMManagerSetDefaultAdapter:
+    def test_set_default_adapter_updates_name(self):
+        """
+        Test set_default_adapter.
+        Asserts that manager.default_adapter_name is updated.
+        """
+        manager = LLMManager()
+        manager.set_default_adapter("my_default")
+        assert manager.default_adapter_name == "my_default"
+
+class TestLLMManagerGetAdapter:
+    def test_get_adapter_by_specific_name_exists(self, mocker):
+        """Scenario 4a: Get by specific name (adapter exists)."""
+        manager = LLMManager()
+        mock_adapter1 = mocker.Mock(spec=LLMAdapter)
+        manager.register_adapter("adapter1", mock_adapter1)
+        
+        result = manager.get_adapter("adapter1")
+        assert result is mock_adapter1
+
+    def test_get_adapter_by_specific_name_does_not_exist(self, mocker):
+        """Scenario 4b: Get by specific name (adapter does not exist)."""
+        manager = LLMManager()
+        # Register a different adapter to ensure it's not just an empty dict issue
+        mock_adapter_other = mocker.Mock(spec=LLMAdapter)
+        manager.register_adapter("other_adapter", mock_adapter_other)
+
+        result = manager.get_adapter("non_existent_adapter")
+        assert result is None
+
+    def test_get_adapter_default_when_name_is_none_default_set_and_exists(self, mocker):
+        """Scenario 4c: Get default adapter when name is None (default is set and adapter exists)."""
+        manager = LLMManager()
+        mock_adapter_default = mocker.Mock(spec=LLMAdapter)
+        manager.register_adapter("default_one", mock_adapter_default)
+        manager.set_default_adapter("default_one")
+        
+        result = manager.get_adapter() # No name, should use default
+        assert result is mock_adapter_default
+
+    def test_get_adapter_default_when_name_is_none_default_not_set(self, mocker):
+        """Scenario 4d: Get default adapter when name is None (default is not set)."""
+        manager = LLMManager()
+        mock_adapter1 = mocker.Mock(spec=LLMAdapter)
+        manager.register_adapter("adapter1", mock_adapter1)
+        # default_adapter_name is "" by default
+        
+        result = manager.get_adapter()
+        assert result is None
+
+    def test_get_adapter_default_when_name_is_none_default_set_but_adapter_not_registered(self, mocker):
+        """Scenario 4e: Get default adapter when name is None (default is set, but adapter with that name is not registered)."""
+        manager = LLMManager()
+        # Register some other adapter to make sure adapters dict isn't empty
+        mock_adapter_other = mocker.Mock(spec=LLMAdapter)
+        manager.register_adapter("other_adapter", mock_adapter_other)
+
+        manager.set_default_adapter("unregistered_default")
+        
+        result = manager.get_adapter()
+        assert result is None
+
+# End of test file

--- a/tests/infrastructure/llm/test_local_llama_adapter.py
+++ b/tests/infrastructure/llm/test_local_llama_adapter.py
@@ -1,0 +1,162 @@
+import pytest
+import asyncio
+from unittest.mock import MagicMock, patch
+
+from rag_core.infrastructure.llm.local_llama_adapter import LocalLlamaAdapter
+from rag_core.infrastructure.llm.base_adapter import LLMAdapter # For patching super().handle_error
+
+# --- Fixtures ---
+
+@pytest.fixture
+def adapter_instance():
+    """Provides a LocalLlamaAdapter instance for tests."""
+    return LocalLlamaAdapter(model_path="path/to/model", temperature=0.5, max_tokens=512)
+
+# --- Test Classes ---
+
+class TestLocalLlamaAdapterInit:
+    def test_init_parameters_and_model_none(self):
+        """
+        Scenario 1: Test __init__.
+        Instantiate LocalLlamaAdapter and assert attributes.
+        Assert adapter.model is None (as per current super().__init__(model=None)).
+        """
+        model_path = "path/to/model"
+        temperature = 0.5
+        max_tokens = 512
+        
+        adapter = LocalLlamaAdapter(
+            model_path=model_path,
+            temperature=temperature,
+            max_tokens=max_tokens
+        )
+        
+        assert adapter.model_path == model_path
+        assert adapter.temperature == temperature
+        assert adapter.max_tokens == max_tokens
+        assert adapter.model is None # As super().__init__(model=None) is called
+
+class TestLocalLlamaAdapterGenerateResponse:
+    def test_successful_placeholder_response(self, adapter_instance):
+        """
+        Scenario 1 (sync generate): Successful placeholder response.
+        """
+        result = adapter_instance.generate_response("test prompt")
+        assert result == "Local model sync result"
+
+    # As per pragmatic approach in instructions, skipping direct test of except block for now.
+
+class TestLocalLlamaAdapterStreamResponse:
+    def test_successful_placeholder_stream(self, adapter_instance):
+        """
+        Scenario 1 (sync stream): Successful placeholder stream.
+        """
+        result = list(adapter_instance.stream_response("test prompt"))
+        assert result == ["Local model streaming part1", "Local model streaming part2"]
+
+    # As per pragmatic approach, skipping direct test of except block for now.
+
+@pytest.mark.asyncio
+class TestLocalLlamaAdapterAsyncGenerateResponse:
+    def test_async_generate_successful_execution(self, adapter_instance, mocker):
+        """
+        Scenario 1 (async generate): Successful execution.
+        Mocks the synchronous adapter.generate_response.
+        """
+        custom_sync_output = "custom sync output for async test"
+        mock_sync_generate = mocker.patch.object(
+            adapter_instance, 
+            'generate_response', 
+            return_value=custom_sync_output
+        )
+        
+        prompt = "test async prompt"
+        result = await adapter_instance.async_generate_response(prompt)
+        
+        mock_sync_generate.assert_called_once_with(prompt)
+        assert result == custom_sync_output
+
+    def test_async_generate_exception_from_sync_method(self, adapter_instance, mocker):
+        """
+        Scenario 2 (async generate): Exception from sync method.
+        Mocks adapter.generate_response to raise RuntimeError.
+        """
+        error_message = "Sync method failed during async call"
+        mocker.patch.object(
+            adapter_instance,
+            'generate_response',
+            side_effect=RuntimeError(error_message)
+        )
+        
+        prompt = "test async prompt causing error"
+        with pytest.raises(RuntimeError, match=error_message):
+            await adapter_instance.async_generate_response(prompt)
+
+@pytest.mark.asyncio
+class TestLocalLlamaAdapterAsyncStreamResponse:
+    def test_async_stream_successful_stream(self, adapter_instance, mocker):
+        """
+        Scenario 1 (async stream): Successful stream.
+        Mocks adapter.stream_response.
+        """
+        custom_sync_parts = ["custom stream part 1", "custom stream part 2"]
+        mock_sync_stream = mocker.patch.object(
+            adapter_instance,
+            'stream_response',
+            return_value=iter(custom_sync_parts) # Ensure it's an iterator
+        )
+        
+        prompt = "test async stream prompt"
+        result_chunks = [chunk async for chunk in adapter_instance.async_stream_response(prompt)]
+        
+        mock_sync_stream.assert_called_once_with(prompt)
+        assert result_chunks == custom_sync_parts
+
+    def test_async_stream_exception_from_sync_method_during_iteration(self, adapter_instance, mocker):
+        """
+        Scenario 2 (async stream): Exception from sync stream method (raised during iteration).
+        """
+        error_message = "Sync stream failed during yield in async call"
+
+        def mock_sync_stream_gen_with_error(prompt_text):
+            yield "part1 from sync error gen"
+            raise RuntimeError(error_message)
+
+        mocker.patch.object(
+            adapter_instance,
+            'stream_response',
+            side_effect=mock_sync_stream_gen_with_error # Use side_effect for generators
+        )
+        
+        prompt = "test async stream error prompt"
+        with pytest.raises(RuntimeError, match=error_message):
+            # Consume the async generator to trigger the exception
+            async_results = []
+            async for chunk in adapter_instance.async_stream_response(prompt):
+                async_results.append(chunk)
+
+
+class TestLocalLlamaAdapterHandleError:
+    def test_handle_error_calls_super(self, adapter_instance, mocker):
+        """
+        Test overridden handle_error method calls super().handle_error.
+        """
+        # Path to LLMAdapter's handle_error within the base_adapter module
+        # This needs to be the location where LLMAdapter (the class itself) is defined
+        # or where it's imported if you're patching an instance's inherited method.
+        # For patching a method on a parent class that will be called via super(),
+        # you patch it on the parent class directly.
+        mock_super_handle_error = mocker.patch(
+            'rag_core.infrastructure.llm.base_adapter.LLMAdapter.handle_error'
+        )
+        
+        test_exception = Exception("LocalLlama specific error details")
+        adapter_instance.handle_error(test_exception)
+        
+        mock_super_handle_error.assert_called_once_with(adapter_instance, test_exception)
+        # Note: The first argument to a method mocked on a class (when called from an instance)
+        # is the instance itself. If you mock `LLMAdapter.handle_error`,
+        # when `adapter_instance.handle_error(test_exception)` calls `super().handle_error(e)`,
+        # the mocked `LLMAdapter.handle_error` receives `adapter_instance` as `self`.
+
+# End of test file

--- a/tests/infrastructure/llm/test_openai_adapter.py
+++ b/tests/infrastructure/llm/test_openai_adapter.py
@@ -1,0 +1,357 @@
+import pytest
+import asyncio
+from unittest.mock import MagicMock, patch, call
+import time # For mocking time.sleep
+
+# Assuming openai is installed in the environment, otherwise this might fail at collection time
+# For testing, we only need the exception type. If actual openai lib is not present,
+# we can create a dummy class for OpenAIError for the tests to run.
+try:
+    from openai import OpenAIError, APIError # APIError is a common one, or RateLimitError, etc.
+except ImportError:
+    # Create a dummy OpenAIError if the library is not installed in the test environment
+    class OpenAIError(Exception):
+        pass
+    class APIError(OpenAIError):
+        pass
+
+
+from rag_core.infrastructure.llm.openai_adapter import OpenAIAdapter
+from rag_core.infrastructure.llm.base_adapter import LLMAdapter # For patching super().handle_error
+
+# --- Fixtures ---
+
+@pytest.fixture
+def mock_openai_client_instance():
+    """Mocks the instance of openai.OpenAI()."""
+    mock_client = MagicMock()
+    # Mock for non-streaming response
+    mock_response_non_stream = MagicMock()
+    mock_response_non_stream.choices = [MagicMock()]
+    mock_response_non_stream.choices[0].message = MagicMock()
+    mock_response_non_stream.choices[0].message.content = "Mocked LLM response"
+    
+    # Mock for streaming response
+    mock_chunk_1 = MagicMock()
+    mock_chunk_1.choices = [MagicMock()]
+    mock_chunk_1.choices[0].delta = MagicMock()
+    mock_chunk_1.choices[0].delta.content = "Hello"
+    
+    mock_chunk_2 = MagicMock()
+    mock_chunk_2.choices = [MagicMock()]
+    mock_chunk_2.choices[0].delta = MagicMock()
+    mock_chunk_2.choices[0].delta.content = " world"
+
+    mock_chunk_3 = MagicMock() # Represents end of stream or None content
+    mock_chunk_3.choices = [MagicMock()]
+    mock_chunk_3.choices[0].delta = MagicMock()
+    mock_chunk_3.choices[0].delta.content = None
+    
+    mock_client.chat.completions.create.side_effect = lambda *args, **kwargs: \
+        iter([mock_chunk_1, mock_chunk_2, mock_chunk_3]) if kwargs.get("stream") else mock_response_non_stream
+        
+    return mock_client
+
+@pytest.fixture
+def mock_openai_class(mocker, mock_openai_client_instance):
+    """Mocks the openai.OpenAI class."""
+    mock_class = mocker.patch('rag_core.infrastructure.llm.openai_adapter.OpenAI', return_value=mock_openai_client_instance)
+    return mock_class
+
+@pytest.fixture
+def mock_log_wrapper(mocker):
+    """Mocks the log_wrapper module."""
+    return mocker.patch('rag_core.infrastructure.llm.openai_adapter.log_wrapper')
+
+@pytest.fixture
+def mock_time_sleep(mocker):
+    """Mocks time.sleep."""
+    return mocker.patch('rag_core.infrastructure.llm.openai_adapter.time.sleep')
+
+
+# --- Test Classes ---
+
+class TestOpenAIAdapterInit:
+    def test_init_valid_parameters(self, mock_openai_class, mock_log_wrapper):
+        """Scenario 1: Valid initialization."""
+        api_key = "sk-testkey123"
+        model_name = "gpt-3.5-turbo"
+        temperature = 0.8
+        max_tokens = 1500
+        
+        adapter = OpenAIAdapter(
+            api_key=api_key,
+            model_name=model_name,
+            temperature=temperature,
+            max_tokens=max_tokens
+        )
+        
+        mock_openai_class.assert_called_once_with(api_key=api_key)
+        assert adapter.model_name == model_name
+        assert adapter.temperature == temperature
+        assert adapter.max_tokens == max_tokens
+        mock_log_wrapper.warning.assert_not_called()
+
+    def test_init_invalid_api_key_empty(self, mock_openai_class, mock_log_wrapper):
+        """Scenario 2: Invalid API key (empty)."""
+        with pytest.raises(ValueError, match="OpenAI API key cannot be empty."):
+            OpenAIAdapter(api_key="", model_name="gpt-3.5-turbo")
+        mock_openai_class.assert_not_called()
+
+    def test_init_api_key_format_warning(self, mock_openai_class, mock_log_wrapper):
+        """Scenario 3: API key format warning (no 'sk-')."""
+        api_key_no_prefix = "testkey123"
+        OpenAIAdapter(api_key=api_key_no_prefix, model_name="gpt-3.5-turbo")
+        
+        mock_openai_class.assert_called_once_with(api_key=api_key_no_prefix)
+        mock_log_wrapper.warning.assert_called_once_with(
+            "OpenAIAdapter",
+            "__init__",
+            f"OpenAI API key '{api_key_no_prefix}' does not start with 'sk-'. This might be an invalid key."
+        )
+
+class TestOpenAIAdapterGenerateResponse:
+    @pytest.fixture
+    def adapter(self, mock_openai_class, mock_log_wrapper): # Ensure mocks are active
+        return OpenAIAdapter(api_key="sk-testkey")
+
+    def test_successful_first_try(self, adapter, mock_openai_client_instance, mock_time_sleep):
+        """Scenario 1: Successful (1st try)."""
+        prompt = "Translate 'hello' to French."
+        response = adapter.generate_response(prompt)
+        
+        mock_openai_client_instance.chat.completions.create.assert_called_once_with(
+            model=adapter.model_name,
+            messages=[{"role": "user", "content": prompt}],
+            temperature=adapter.temperature,
+            max_tokens=adapter.max_tokens,
+            stream=False
+        )
+        assert response == "Mocked LLM response"
+        mock_time_sleep.assert_not_called()
+
+    def test_successful_after_retries(self, adapter, mock_openai_client_instance, mock_log_wrapper, mock_time_sleep):
+        """Scenario 2: Successful (after retries)."""
+        prompt = "Why is the sky blue?"
+        
+        # Setup side effects for chat.completions.create
+        # First two calls raise OpenAIError, third one returns a valid response
+        mock_valid_response = MagicMock()
+        mock_valid_response.choices = [MagicMock()]
+        mock_valid_response.choices[0].message = MagicMock()
+        mock_valid_response.choices[0].message.content = "Finally succeeded"
+
+        mock_openai_client_instance.chat.completions.create.side_effect = [
+            OpenAIError("Simulated error 1"),
+            APIError("Simulated API error 2"), # APIError is a subclass of OpenAIError
+            mock_valid_response 
+        ]
+        
+        response = adapter.generate_response(prompt)
+        
+        assert response == "Finally succeeded"
+        assert mock_openai_client_instance.chat.completions.create.call_count == 3
+        assert mock_time_sleep.call_count == 2
+        # Check log calls for retries
+        mock_log_wrapper.error.assert_any_call(
+            "OpenAIAdapter", "generate_response", "OpenAI API error: Simulated error 1. Retrying (1/2)..."
+        )
+        mock_log_wrapper.error.assert_any_call(
+            "OpenAIAdapter", "generate_response", "OpenAI API error: Simulated API error 2. Retrying (2/2)..."
+        )
+
+
+    def test_failure_all_retries(self, adapter, mock_openai_client_instance, mock_log_wrapper, mock_time_sleep):
+        """Scenario 3: Failure (all retries)."""
+        prompt = "Explain quantum physics simply."
+        mock_openai_client_instance.chat.completions.create.side_effect = OpenAIError("Persistent failure")
+        
+        with pytest.raises(OpenAIError, match="Persistent failure"):
+            adapter.generate_response(prompt)
+            
+        assert mock_openai_client_instance.chat.completions.create.call_count == 3
+        assert mock_time_sleep.call_count == 2
+        mock_log_wrapper.error.assert_any_call(
+            "OpenAIAdapter", "generate_response", "OpenAI API error: Persistent failure. Retrying (1/2)..."
+        )
+        mock_log_wrapper.error.assert_any_call(
+            "OpenAIAdapter", "generate_response", "OpenAI API error: Persistent failure. Retrying (2/2)..."
+        )
+        mock_log_wrapper.error.assert_any_call(
+            "OpenAIAdapter", "generate_response", "OpenAI API error after 3 retries: Persistent failure"
+        )
+
+
+    @pytest.mark.parametrize("error_message, specific_log_message", [
+        ("Connection error details", "OpenAI API error: Connection error details"),
+        ("Invalid API key provided.", "OpenAI API error: Invalid API key provided.")
+    ])
+    def test_specific_openai_error_logging(self, adapter, mock_openai_client_instance, mock_log_wrapper, error_message, specific_log_message):
+        """Scenario 4: Specific OpenAIError logging (final failure)."""
+        prompt = "Test specific error."
+        mock_openai_client_instance.chat.completions.create.side_effect = OpenAIError(error_message)
+
+        with pytest.raises(OpenAIError):
+            adapter.generate_response(prompt)
+        
+        # Check the final error log after all retries
+        mock_log_wrapper.error.assert_any_call(
+            "OpenAIAdapter", "generate_response", f"{specific_log_message} after 3 retries" # Adjusted to match the new format
+        )
+
+
+class TestOpenAIAdapterStreamResponse:
+    @pytest.fixture
+    def adapter(self, mock_openai_class, mock_log_wrapper):
+        return OpenAIAdapter(api_key="sk-testkey")
+
+    def test_successful_stream(self, adapter, mock_openai_client_instance):
+        """Scenario 1: Successful stream."""
+        prompt = "Stream a short story."
+        
+        # The default side_effect of mock_openai_client_instance.chat.completions.create
+        # already handles streaming mocks.
+        
+        response_chunks = list(adapter.stream_response(prompt))
+        
+        mock_openai_client_instance.chat.completions.create.assert_called_once_with(
+            model=adapter.model_name,
+            messages=[{"role": "user", "content": prompt}],
+            temperature=adapter.temperature,
+            max_tokens=adapter.max_tokens,
+            stream=True  # Crucial for streaming
+        )
+        
+        collected_content = "".join(response_chunks)
+        assert collected_content == "Hello world" # Based on mock_openai_client_instance setup
+
+    def test_openai_error_during_stream(self, adapter, mock_openai_client_instance, mocker):
+        """Scenario 2: OpenAIError during stream."""
+        prompt = "This stream will fail."
+        mock_openai_client_instance.chat.completions.create.side_effect = OpenAIError("Stream connection broken")
+        
+        # Mock the adapter's own handle_error method for this specific test
+        mock_handle_error = mocker.patch.object(adapter, 'handle_error')
+        
+        # Consume the generator to trigger the exception
+        with pytest.raises(OpenAIError, match="Stream connection broken"):
+            list(adapter.stream_response(prompt))
+            
+        mock_handle_error.assert_called_once()
+        # Check that the exception passed to handle_error is the one raised
+        args, _ = mock_handle_error.call_args
+        assert isinstance(args[0], OpenAIError)
+        assert "Stream connection broken" in str(args[0])
+
+
+@pytest.mark.asyncio
+class TestOpenAIAdapterAsyncGenerateResponse:
+    @pytest.fixture
+    def adapter(self, mock_openai_class, mock_log_wrapper):
+        return OpenAIAdapter(api_key="sk-testkey")
+
+    async def test_async_generate_response_successful(self, adapter, mocker, mock_log_wrapper):
+        """Scenario 1 (async): Success."""
+        prompt = "Async prompt"
+        expected_sync_response = "Async success via sync mock"
+        
+        # Mock the synchronous generate_response method on the instance
+        mock_sync_generate = mocker.patch.object(adapter, 'generate_response', return_value=expected_sync_response)
+        
+        result = await adapter.async_generate_response(prompt)
+        
+        assert result == expected_sync_response
+        mock_sync_generate.assert_called_once_with(prompt)
+        # Ensure the adapter's own error logging within async_generate_response is not called
+        # by filtering out handle_error calls made by the sync generate_response
+        # For this test, we only care that async_generate_response itself doesn't log an *additional* error.
+        # If generate_response were to fail, it would log via its own handle_error.
+        
+        # Get all calls to log_wrapper.error
+        error_log_calls = mock_log_wrapper.error.call_args_list
+        # Filter out calls that might originate from the (mocked) synchronous generate_response's internal error handling
+        async_method_specific_logs = [
+            c for c in error_log_calls 
+            if c.args[0] == "OpenAIAdapter" and c.args[1] == "async_generate_response"
+        ]
+        assert not async_method_specific_logs
+
+
+    async def test_async_generate_response_exception(self, adapter, mocker, mock_log_wrapper):
+        """Scenario 2 (async): Exception from generate_response."""
+        prompt = "Async prompt causing error"
+        original_exception = OpenAIError("Error from sync generate_response")
+        
+        mocker.patch.object(adapter, 'generate_response', side_effect=original_exception)
+        
+        with pytest.raises(OpenAIError, match="Error from sync generate_response"):
+            await adapter.async_generate_response(prompt)
+            
+        # Check that the async method's own error logging was called
+        mock_log_wrapper.error.assert_any_call(
+            "OpenAIAdapter",
+            "async_generate_response",
+            f"Error in async_generate_response: {str(original_exception)}"
+        )
+
+
+@pytest.mark.asyncio
+class TestOpenAIAdapterAsyncStreamResponse:
+    @pytest.fixture
+    def adapter(self, mock_openai_class, mock_log_wrapper):
+        return OpenAIAdapter(api_key="sk-testkey")
+
+    async def test_async_stream_response_successful(self, adapter, mocker):
+        """Scenario 1 (async stream): Success."""
+        prompt = "Async stream prompt"
+        expected_chunks = ["chunk1 ", "chunk2"]
+        
+        # Mock the synchronous stream_response method on the instance
+        mock_sync_stream = mocker.patch.object(adapter, 'stream_response', return_value=iter(expected_chunks))
+        
+        collected_chunks = []
+        async for chunk in adapter.async_stream_response(prompt):
+            collected_chunks.append(chunk)
+            
+        assert "".join(collected_chunks) == "".join(expected_chunks)
+        mock_sync_stream.assert_called_once_with(prompt)
+
+    async def test_async_stream_response_exception(self, adapter, mocker, mock_log_wrapper):
+        """ Test exception propagation from sync stream_response in async version. """
+        prompt = "Async stream failing"
+        original_exception = OpenAIError("Error from sync stream_response")
+
+        mocker.patch.object(adapter, 'stream_response', side_effect=original_exception)
+
+        with pytest.raises(OpenAIError, match="Error from sync stream_response"):
+            async for _ in adapter.async_stream_response(prompt):
+                pass
+        
+        # Assert that the specific log in async_stream_response is called
+        mock_log_wrapper.error.assert_any_call(
+             "OpenAIAdapter",
+             "async_stream_response",
+             f"Error in async_stream_response: {str(original_exception)}"
+        )
+
+
+class TestOpenAIAdapterHandleErrorOverridden:
+    @pytest.fixture
+    def adapter(self, mock_openai_class): # log_wrapper is not directly used by this test's handle_error
+        return OpenAIAdapter(api_key="sk-testkey")
+
+    def test_handle_error_calls_super_and_logs_openai_specific(self, adapter, mocker, mock_log_wrapper): # mock_log_wrapper needed here
+        """Test overridden handle_error method."""
+        mock_super_handle_error = mocker.patch.object(LLMAdapter, 'handle_error') # Patch on the parent
+        
+        test_exception = Exception("OpenAI detail error")
+        adapter.handle_error(test_exception)
+        
+        mock_super_handle_error.assert_called_once_with(test_exception)
+        mock_log_wrapper.error.assert_any_call( # Use any_call if super also logs
+            "OpenAIAdapter", # Class name from the overridden method
+            "handle_error",  # Method name
+            f"OpenAI Specific Error: {str(test_exception)}" # OpenAIAdapter's specific message
+        )
+
+# End of test file

--- a/tests/infrastructure/test_embedding_manager.py
+++ b/tests/infrastructure/test_embedding_manager.py
@@ -1,0 +1,174 @@
+import pytest
+import asyncio
+from unittest.mock import MagicMock, patch, call
+from concurrent.futures import ThreadPoolExecutor
+
+from src.rag_core.infrastructure.embedding import EmbeddingManager
+from langchain_openai import OpenAIEmbeddings # Used for type hinting if needed, but will be mocked
+
+# Sample data
+SAMPLE_API_KEY = "test_api_key_explicit"
+SAMPLE_MODEL_NAME = "test_model_explicit"
+SAMPLE_EMBEDDING_VECTOR = [0.1, 0.2, 0.3, 0.4, 0.5]
+SAMPLE_TEXT_TO_EMBED = "This is a test text."
+
+@pytest.fixture
+def mock_config_manager_settings(mocker):
+    mock_settings = MagicMock()
+    mock_settings.api_keys.openai = "test_api_key_from_config"
+    mock_settings.embedding.model = "test_model_from_config"
+    mock_settings.thread_pool.embed_pool = 5 # Example value for max_workers
+    
+    mocker.patch('src.rag_core.infrastructure.embedding.config_manager', mock_settings)
+    return mock_settings
+
+@pytest.fixture
+def mock_openai_embeddings_class(mocker):
+    mock_instance = MagicMock(spec=OpenAIEmbeddings) # Use spec for better mocking
+    mock_instance.embed_query = MagicMock(return_value=SAMPLE_EMBEDDING_VECTOR)
+    
+    mock_class = MagicMock(return_value=mock_instance)
+    mocker.patch('src.rag_core.infrastructure.embedding.OpenAIEmbeddings', mock_class)
+    return mock_class, mock_instance
+
+
+class TestEmbeddingManagerInit:
+    def test_init_with_explicit_parameters(self, mock_openai_embeddings_class, mock_config_manager_settings):
+        """
+        Test EmbeddingManager instantiation with explicit API key and model name.
+        Verifies OpenAIEmbeddings is called with these explicit parameters.
+        """
+        mock_class, _ = mock_openai_embeddings_class
+        
+        manager = EmbeddingManager(
+            openai_api_key=SAMPLE_API_KEY,
+            embedding_model_name=SAMPLE_MODEL_NAME
+        )
+        
+        mock_class.assert_called_once_with(
+            api_key=SAMPLE_API_KEY,
+            model=SAMPLE_MODEL_NAME
+        )
+        assert manager._executor is not None # Check executor is initialized
+
+    def test_init_with_config_values(self, mock_openai_embeddings_class, mock_config_manager_settings):
+        """
+        Test EmbeddingManager instantiation using values from config_manager.settings.
+        Verifies OpenAIEmbeddings is called with values from the mocked config.
+        """
+        mock_class, _ = mock_openai_embeddings_class
+        settings = mock_config_manager_settings # Ensure fixture is used to patch
+
+        manager = EmbeddingManager() # No explicit params
+        
+        mock_class.assert_called_once_with(
+            api_key=settings.api_keys.openai,
+            model=settings.embedding.model
+        )
+        assert manager._executor is not None
+
+
+class TestEmbeddingManagerGenerateEmbedding:
+    def test_generate_embedding_successful(self, mock_openai_embeddings_class, mock_config_manager_settings):
+        """
+        Test successful embedding generation.
+        """
+        _, mock_instance = mock_openai_embeddings_class
+        manager = EmbeddingManager()
+        
+        result = manager.generate_embedding(SAMPLE_TEXT_TO_EMBED)
+        
+        mock_instance.embed_query.assert_called_once_with(SAMPLE_TEXT_TO_EMBED)
+        assert result == SAMPLE_EMBEDDING_VECTOR
+
+    @pytest.mark.parametrize("empty_return_value", [None, []])
+    def test_generate_embedding_empty_result_from_model(self, mock_openai_embeddings_class, mock_config_manager_settings, empty_return_value):
+        """
+        Test ValueError is raised when OpenAIEmbeddings().embed_query returns None or [].
+        """
+        _, mock_instance = mock_openai_embeddings_class
+        mock_instance.embed_query.return_value = empty_return_value
+        
+        manager = EmbeddingManager()
+        
+        with pytest.raises(ValueError) as excinfo:
+            manager.generate_embedding(SAMPLE_TEXT_TO_EMBED)
+        assert "Embedding generation failed: No embedding vector returned." in str(excinfo.value)
+
+    def test_generate_embedding_exception_from_model(self, mock_openai_embeddings_class, mock_config_manager_settings):
+        """
+        Test that an exception from OpenAIEmbeddings().embed_query is re-raised.
+        """
+        _, mock_instance = mock_openai_embeddings_class
+        original_exception = ConnectionError("Simulated API connection error")
+        mock_instance.embed_query.side_effect = original_exception
+        
+        manager = EmbeddingManager()
+        
+        with pytest.raises(ConnectionError) as excinfo:
+            manager.generate_embedding(SAMPLE_TEXT_TO_EMBED)
+        assert excinfo.value == original_exception
+
+
+@pytest.mark.asyncio
+class TestEmbeddingManagerGenerateEmbeddingAsync:
+    async def test_generate_embedding_async_successful(self, mocker, mock_config_manager_settings):
+        """
+        Test successful async embedding generation.
+        Mocks the synchronous generate_embedding method.
+        """
+        manager = EmbeddingManager() # Real manager, but its sync method will be mocked
+
+        # Mock the synchronous method on the instance
+        mocked_sync_generate = MagicMock(return_value=SAMPLE_EMBEDDING_VECTOR)
+        mocker.patch.object(manager, 'generate_embedding', new=mocked_sync_generate)
+        
+        result = await manager.generate_embedding_async(SAMPLE_TEXT_TO_EMBED)
+        
+        mocked_sync_generate.assert_called_once_with(SAMPLE_TEXT_TO_EMBED)
+        assert result == SAMPLE_EMBEDDING_VECTOR
+        # Ensure the executor was used by checking for loop.run_in_executor's call
+        # This is a bit more involved, might need to mock asyncio.get_event_loop() if direct assertion is hard
+
+    async def test_generate_embedding_async_exception_in_sync_call(self, mocker, mock_config_manager_settings):
+        """
+        Test exception propagation from the synchronous call in async version.
+        """
+        manager = EmbeddingManager()
+        original_exception = ValueError("Simulated error in sync generate_embedding")
+
+        mocked_sync_generate = MagicMock(side_effect=original_exception)
+        mocker.patch.object(manager, 'generate_embedding', new=mocked_sync_generate)
+        
+        with pytest.raises(ValueError) as excinfo:
+            await manager.generate_embedding_async(SAMPLE_TEXT_TO_EMBED)
+        
+        mocked_sync_generate.assert_called_once_with(SAMPLE_TEXT_TO_EMBED)
+        assert excinfo.value == original_exception
+
+
+class TestEmbeddingManagerShutdown:
+    def test_shutdown_calls_executor_shutdown(self, mock_config_manager_settings, mocker):
+        """
+        Test that manager.shutdown() calls _executor.shutdown(wait=False).
+        """
+        manager = EmbeddingManager() # Initializes a real ThreadPoolExecutor
+
+        # Mock the _executor attribute on this specific instance AFTER it's created
+        mock_executor_instance = MagicMock(spec=ThreadPoolExecutor)
+        manager._executor = mock_executor_instance # Replace the real executor with a mock
+
+        manager.shutdown()
+        
+        mock_executor_instance.shutdown.assert_called_once_with(wait=False)
+
+    def test_shutdown_handles_no_executor(self, mock_config_manager_settings):
+        """ Test that shutdown doesn't fail if _executor is None (e.g., if init failed before executor creation). """
+        manager = EmbeddingManager()
+        manager._executor = None # Simulate a scenario where executor wasn't created or was nulled
+        try:
+            manager.shutdown() # Should not raise an error
+        except Exception as e:
+            pytest.fail(f"manager.shutdown() raised an exception unexpectedly: {e}")
+
+# End of test file

--- a/tests/infrastructure/test_vector_store.py
+++ b/tests/infrastructure/test_vector_store.py
@@ -1,0 +1,870 @@
+import pytest
+import asyncio
+import uuid
+from unittest.mock import MagicMock, patch, call, ANY
+
+# Qdrant specific imports for mocking and type hints
+from qdrant_client import QdrantClient, models
+from qdrant_client.models import PointStruct, ScoredPoint, PointRecord, Distance, VectorParams, Filter, FieldCondition, MatchValue
+
+# Project specific imports
+from src.rag_core.infrastructure.vector_store import VectorIndex
+from src.rag_core.infrastructure.embedding import EmbeddingManager # For spec
+from src.rag_core.domain.schema_checker import DataStructureChecker # For spec
+
+# --- Fixtures ---
+
+@pytest.fixture
+def mock_qdrant_client_instance(mocker):
+    """Mocks the instance of QdrantClient."""
+    mock_client = MagicMock(spec=QdrantClient)
+    
+    # Mock get_collection: by default, assume collection exists
+    mock_client.get_collection = MagicMock()
+    
+    # Mock create_collection
+    mock_client.create_collection = MagicMock()
+    
+    # Mock upsert
+    mock_client.upsert = MagicMock()
+    
+    # Mock search - default to returning a list of ScoredPoint mocks
+    mock_scored_point1 = MagicMock(spec=ScoredPoint)
+    mock_scored_point1.id = str(uuid.uuid4())
+    mock_scored_point1.payload = {"uid": "doc1", "text": "Document 1 text", "orig_sid":"orig_doc1_sid", "side":"default_side"}
+    mock_scored_point1.score = 0.9
+    mock_scored_point1.vector = [0.1] * 10 # Dummy vector
+
+    mock_scored_point2 = MagicMock(spec=ScoredPoint)
+    mock_scored_point2.id = str(uuid.uuid4())
+    mock_scored_point2.payload = {"uid": "doc2", "text": "Document 2 text", "orig_sid":"orig_doc2_sid", "side":"default_side"}
+    mock_scored_point2.score = 0.8
+    mock_scored_point2.vector = [0.2] * 10 # Dummy vector
+    
+    mock_client.search = MagicMock(return_value=[mock_scored_point1, mock_scored_point2])
+    
+    # Mock delete
+    mock_client.delete = MagicMock()
+    
+    # Mock retrieve - default to returning a list of PointRecord mocks
+    mock_point_record = MagicMock(spec=PointRecord)
+    mock_point_record.id = str(uuid.uuid4())
+    mock_point_record.payload = {"uid": "retrieved_doc", "text": "Retrieved document text"}
+    mock_point_record.vector = [0.3] * 10 # Dummy vector
+    mock_client.retrieve = MagicMock(return_value=[mock_point_record])
+    
+    return mock_client
+
+@pytest.fixture
+def mock_qdrant_client_class(mocker, mock_qdrant_client_instance):
+    """Mocks the QdrantClient class, returning the mocked instance."""
+    mock_class = mocker.patch('src.rag_core.infrastructure.vector_store.QdrantClient', return_value=mock_qdrant_client_instance)
+    return mock_class
+
+@pytest.fixture
+def mock_embedding_manager(mocker):
+    """Mocks EmbeddingManager."""
+    mock_em = mocker.Mock(spec=EmbeddingManager)
+    mock_em.generate_embedding = MagicMock(return_value=[0.1, 0.2, 0.3]) # Sample embedding
+    return mock_em
+
+@pytest.fixture
+def mock_data_structure_checker(mocker):
+    """Mocks DataStructureChecker."""
+    # By default, validate does nothing (passes)
+    mock_dsc = mocker.Mock(spec=DataStructureChecker)
+    mock_dsc.validate = MagicMock() 
+    return mock_dsc
+
+@pytest.fixture
+def mock_config_manager_settings(mocker):
+    """Mocks config_manager.settings."""
+    mock_settings = MagicMock()
+    mock_settings.vector_db.collection = "test_collection"
+    mock_settings.vector_db.vector_size = 10 # Must match dummy vectors if used
+    mock_settings.vector_db.qdrant_host = "localhost"
+    mock_settings.vector_db.qdrant_port = 6333
+    mock_settings.thread_pool.vector_pool = 4 # Example value
+    
+    mocker.patch('src.rag_core.infrastructure.vector_store.config_manager', mock_settings)
+    return mock_settings
+
+@pytest.fixture
+def mock_log_wrapper(mocker):
+    """Mocks log_wrapper."""
+    return mocker.patch('src.rag_core.infrastructure.vector_store.log_wrapper')
+
+@pytest.fixture
+def mock_uuid5(mocker):
+    """Mocks uuid.uuid5 to return predictable UUIDs based on input."""
+    # This allows us to check point IDs if they are derived from UIDs
+    def deterministic_uuid5(namespace, name):
+        # Simple mock: return a string that includes the name for easy assertion
+        return f"uuid_for_{name}" 
+    
+    return mocker.patch('src.rag_core.infrastructure.vector_store.uuid.uuid5', side_effect=deterministic_uuid5)
+
+
+# --- Test Classes ---
+
+class TestVectorIndexInit:
+    def test_init_collection_exists(self, mock_qdrant_client_class, mock_qdrant_client_instance, 
+                                    mock_embedding_manager, mock_data_structure_checker, 
+                                    mock_config_manager_settings, mock_log_wrapper):
+        """
+        Scenario 1: Default collection exists.
+        `qdrant_client.get_collection` succeeds.
+        `create_collection` NOT called.
+        """
+        # get_collection is mocked to succeed by default in mock_qdrant_client_instance
+        
+        vector_index = VectorIndex(
+            embedding_manager=mock_embedding_manager,
+            data_checker=mock_data_structure_checker
+        )
+        
+        mock_qdrant_client_class.assert_called_once_with(
+            host=mock_config_manager_settings.vector_db.qdrant_host,
+            port=mock_config_manager_settings.vector_db.qdrant_port
+        )
+        mock_qdrant_client_instance.get_collection.assert_called_once_with(
+            collection_name=mock_config_manager_settings.vector_db.collection
+        )
+        mock_qdrant_client_instance.create_collection.assert_not_called()
+        mock_log_wrapper.info.assert_any_call(
+            "VectorIndex", "__init__", 
+            f"Successfully connected to Qdrant. Collection '{mock_config_manager_settings.vector_db.collection}' exists."
+        )
+        assert vector_index.collection_name == mock_config_manager_settings.vector_db.collection
+
+    def test_init_collection_does_not_exist_create_success(
+            self, mock_qdrant_client_class, mock_qdrant_client_instance, 
+            mock_embedding_manager, mock_data_structure_checker, 
+            mock_config_manager_settings, mock_log_wrapper):
+        """
+        Scenario 2: Default collection does not exist, create success.
+        `get_collection` raises an error (simulating collection not found).
+        `create_collection` is called and succeeds.
+        """
+        # Simulate get_collection failing (e.g., collection not found)
+        # The actual error from qdrant_client might be more specific, like ValueError or an unexpected RPC error.
+        # For this test, a generic Exception is fine as the code catches `Exception`.
+        mock_qdrant_client_instance.get_collection.side_effect = Exception("Collection not found")
+        
+        vector_index = VectorIndex(
+            embedding_manager=mock_embedding_manager,
+            data_checker=mock_data_structure_checker
+        )
+        
+        mock_qdrant_client_instance.get_collection.assert_called_once_with(
+            collection_name=mock_config_manager_settings.vector_db.collection
+        )
+        mock_qdrant_client_instance.create_collection.assert_called_once_with(
+            collection_name=mock_config_manager_settings.vector_db.collection,
+            vectors_config=models.VectorParams(
+                size=mock_config_manager_settings.vector_db.vector_size,
+                distance=models.Distance.COSINE # Assuming COSINE is default or configured
+            )
+        )
+        mock_log_wrapper.info.assert_any_call(
+            "VectorIndex", "__init__", 
+            f"Collection '{mock_config_manager_settings.vector_db.collection}' not found. Attempting to create."
+        )
+        mock_log_wrapper.info.assert_any_call(
+            "VectorIndex", "__init__", 
+            f"Collection '{mock_config_manager_settings.vector_db.collection}' created successfully."
+        )
+
+    def test_init_collection_creation_fails(
+            self, mock_qdrant_client_class, mock_qdrant_client_instance, 
+            mock_embedding_manager, mock_data_structure_checker, 
+            mock_config_manager_settings, mock_log_wrapper):
+        """
+        Scenario 3: Default collection creation fails.
+        `get_collection` raises an error.
+        `create_collection` also raises an error.
+        `pytest.raises` during VectorIndex instantiation.
+        """
+        mock_qdrant_client_instance.get_collection.side_effect = Exception("Collection not found initially")
+        mock_qdrant_client_instance.create_collection.side_effect = Exception("Failed to create collection")
+        
+        with pytest.raises(Exception, match="Failed to create collection"):
+            VectorIndex(
+                embedding_manager=mock_embedding_manager,
+                data_checker=mock_data_structure_checker
+            )
+        
+        mock_log_wrapper.error.assert_any_call(
+            "VectorIndex", "__init__", 
+            f"Failed to create collection '{mock_config_manager_settings.vector_db.collection}'. Error: Failed to create collection"
+        )
+
+class TestVectorIndexUidToPointId:
+    def test_uid_to_point_id_consistency(self):
+        """
+        Scenario 1: Consistency.
+        _uid_to_point_id("uid1") == _uid_to_point_id("uid1").
+        """
+        uid = "test_uid_123"
+        point_id1 = VectorIndex._uid_to_point_id(uid)
+        point_id2 = VectorIndex._uid_to_point_id(uid)
+        assert point_id1 == point_id2
+        # Also check if it's a valid UUID string (optional, but good for sanity)
+        assert isinstance(uuid.UUID(point_id1), uuid.UUID)
+
+    def test_uid_to_point_id_uniqueness(self):
+        """
+        Scenario 2: Uniqueness.
+        _uid_to_point_id("uid1") != _uid_to_point_id("uid2").
+        """
+        uid1 = "test_uid_1"
+        uid2 = "test_uid_2"
+        point_id1 = VectorIndex._uid_to_point_id(uid1)
+        point_id2 = VectorIndex._uid_to_point_id(uid2)
+        assert point_id1 != point_id2
+
+class TestVectorIndexCreateCollectionPublic:
+    # This method is very similar to the __init__ logic for collection creation.
+    # We can simplify tests if the core logic is robustly tested in __init__.
+    
+    def test_create_collection_new_name_success(
+            self, mock_qdrant_client_class, mock_qdrant_client_instance, 
+            mock_embedding_manager, mock_data_structure_checker, 
+            mock_config_manager_settings, mock_log_wrapper):
+        """
+        Scenario 1 (similar to __init__ Scen 2): New collection name, create success.
+        """
+        new_collection_name = "new_custom_collection"
+        # Simulate get_collection failing for the new name
+        mock_qdrant_client_instance.get_collection.side_effect = Exception("Collection not found")
+        
+        vector_index = VectorIndex( # Initialize with default collection first
+            embedding_manager=mock_embedding_manager,
+            data_checker=mock_data_structure_checker
+        )
+        # Reset mocks for the specific call to the public create_collection
+        mock_qdrant_client_instance.get_collection.reset_mock(side_effect=True)
+        mock_qdrant_client_instance.create_collection.reset_mock()
+        mock_qdrant_client_instance.get_collection.side_effect = Exception("New collection not found")
+
+
+        vector_index.create_collection(collection_name=new_collection_name, vector_size=128)
+        
+        mock_qdrant_client_instance.get_collection.assert_called_once_with(
+            collection_name=new_collection_name
+        )
+        mock_qdrant_client_instance.create_collection.assert_called_once_with(
+            collection_name=new_collection_name,
+            vectors_config=models.VectorParams(
+                size=128, # Explicitly passed vector_size
+                distance=models.Distance.COSINE
+            )
+        )
+        mock_log_wrapper.info.assert_any_call(
+            "VectorIndex", "create_collection", 
+            f"Collection '{new_collection_name}' not found. Attempting to create."
+        )
+        mock_log_wrapper.info.assert_any_call(
+            "VectorIndex", "create_collection", 
+            f"Collection '{new_collection_name}' created successfully."
+        )
+
+    def test_create_collection_already_exists(
+            self, mock_qdrant_client_class, mock_qdrant_client_instance, 
+            mock_embedding_manager, mock_data_structure_checker, 
+            mock_config_manager_settings, mock_log_wrapper):
+        """
+        Scenario (similar to __init__ Scen 1): Collection with given name already exists.
+        """
+        existing_collection_name = "already_exists_collection"
+        # get_collection will succeed by default from main fixture for this name
+        mock_qdrant_client_instance.get_collection.side_effect = None 
+        
+        vector_index = VectorIndex(
+            embedding_manager=mock_embedding_manager,
+            data_checker=mock_data_structure_checker
+        )
+        # Reset mocks for the specific call
+        mock_qdrant_client_instance.get_collection.reset_mock()
+        mock_qdrant_client_instance.create_collection.reset_mock()
+
+        vector_index.create_collection(collection_name=existing_collection_name, vector_size=128)
+        
+        mock_qdrant_client_instance.get_collection.assert_called_once_with(
+            collection_name=existing_collection_name
+        )
+        mock_qdrant_client_instance.create_collection.assert_not_called()
+        mock_log_wrapper.info.assert_any_call(
+            "VectorIndex", "create_collection", 
+            f"Collection '{existing_collection_name}' already exists. No action taken."
+        )
+
+    def test_create_collection_fails_on_creation_attempt(
+            self, mock_qdrant_client_class, mock_qdrant_client_instance, 
+            mock_embedding_manager, mock_data_structure_checker, 
+            mock_config_manager_settings, mock_log_wrapper):
+        """
+        Scenario (similar to __init__ Scen 3): Creation attempt fails.
+        """
+        failing_collection_name = "failing_creation_collection"
+        mock_qdrant_client_instance.get_collection.side_effect = Exception("Collection not found")
+        mock_qdrant_client_instance.create_collection.side_effect = Exception("Creation RPC error")
+        
+        vector_index = VectorIndex(
+            embedding_manager=mock_embedding_manager,
+            data_checker=mock_data_structure_checker
+        )
+        mock_qdrant_client_instance.get_collection.reset_mock(side_effect=True) # Reset for the specific call
+        mock_qdrant_client_instance.create_collection.reset_mock(side_effect=True)
+        mock_qdrant_client_instance.get_collection.side_effect = Exception("Collection not found")
+        mock_qdrant_client_instance.create_collection.side_effect = Exception("Creation RPC error")
+
+
+        with pytest.raises(Exception, match="Creation RPC error"):
+            vector_index.create_collection(collection_name=failing_collection_name, vector_size=128)
+            
+        mock_log_wrapper.error.assert_any_call(
+            "VectorIndex", "create_collection", 
+            f"Failed to create collection '{failing_collection_name}'. Error: Creation RPC error"
+        )
+
+class TestVectorIndexIngestJson:
+    @pytest.fixture
+    def vector_index_instance(self, mock_qdrant_client_class, mock_embedding_manager, 
+                              mock_data_structure_checker, mock_config_manager_settings):
+        # This fixture provides a VectorIndex instance for ingest_json tests
+        # It relies on the other fixtures to set up mocks correctly.
+        return VectorIndex(
+            embedding_manager=mock_embedding_manager,
+            data_checker=mock_data_structure_checker
+        )
+
+    def test_ingest_json_success(self, vector_index_instance, mock_embedding_manager, 
+                                 mock_qdrant_client_instance, mock_data_structure_checker, 
+                                 mock_log_wrapper, mock_uuid5):
+        """
+        Scenario 1: Success. Valid data.
+        `embedding_manager.generate_embedding` called per item.
+        `qdrant_client.upsert` called with correct `PointStruct`s.
+        """
+        valid_data = [
+            {"uid": "doc1", "text": "Text for document 1", "orig_sid": "orig_s1", "side": "A"},
+            {"uid": "doc2", "text": "Text for document 2", "orig_sid": "orig_s2", "side": "B", "extra_payload": "value"}
+        ]
+        # Mock embeddings for each document
+        mock_embedding_manager.generate_embedding.side_effect = [
+            [0.1] * 10, # Embedding for doc1
+            [0.2] * 10  # Embedding for doc2
+        ]
+        
+        vector_index_instance.ingest_json(valid_data)
+
+        # Verify data_structure_checker.validate was called
+        mock_data_structure_checker.validate.assert_called_once_with(valid_data, mode="input")
+
+        # Verify generate_embedding calls
+        assert mock_embedding_manager.generate_embedding.call_count == 2
+        mock_embedding_manager.generate_embedding.assert_any_call("Text for document 1")
+        mock_embedding_manager.generate_embedding.assert_any_call("Text for document 2")
+
+        # Verify upsert call
+        mock_qdrant_client_instance.upsert.assert_called_once()
+        args, kwargs = mock_qdrant_client_instance.upsert.call_args
+        
+        assert kwargs['collection_name'] == vector_index_instance.collection_name
+        
+        points_arg = kwargs['points']
+        assert len(points_arg) == 2
+        
+        # Check point 1
+        assert points_arg[0].id == VectorIndex._uid_to_point_id("doc1") # Using the actual static method for consistency
+        assert points_arg[0].vector == [0.1] * 10
+        assert points_arg[0].payload == {"uid": "doc1", "text": "Text for document 1", "orig_sid": "orig_s1", "side": "A"}
+        
+        # Check point 2
+        assert points_arg[1].id == VectorIndex._uid_to_point_id("doc2")
+        assert points_arg[1].vector == [0.2] * 10
+        assert points_arg[1].payload == {"uid": "doc2", "text": "Text for document 2", "orig_sid": "orig_s2", "side": "B", "extra_payload": "value"}
+        
+        mock_log_wrapper.info.assert_any_call(
+            "VectorIndex", "ingest_json", 
+            f"Successfully ingested {len(valid_data)} documents into '{vector_index_instance.collection_name}'."
+        )
+
+    def test_ingest_json_empty_data(self, vector_index_instance, mock_qdrant_client_instance, mock_log_wrapper):
+        """
+        Scenario 2: Empty data. `log_wrapper.warning` called, `upsert` not called.
+        """
+        vector_index_instance.ingest_json([])
+        
+        mock_log_wrapper.warning.assert_called_once_with(
+            "VectorIndex", "ingest_json", "No documents provided for ingestion."
+        )
+        mock_qdrant_client_instance.upsert.assert_not_called()
+
+    @pytest.mark.parametrize("missing_key_data, missing_field", [
+        ([{"text": "No uid here"}], "uid"),
+        ([{"uid": "doc_no_text"}], "text")
+    ])
+    def test_ingest_json_missing_uid_or_text(self, vector_index_instance, mock_qdrant_client_instance, 
+                                             mock_log_wrapper, missing_key_data, missing_field):
+        """
+        Scenario 3: Missing `uid` or `text`. `log_wrapper.error` called, `upsert` not called.
+        """
+        vector_index_instance.ingest_json(missing_key_data)
+        
+        mock_log_wrapper.error.assert_called_once_with(
+            "VectorIndex", "ingest_json", 
+            f"Document missing '{missing_field}' field: {missing_key_data[0]}"
+        )
+        mock_qdrant_client_instance.upsert.assert_not_called()
+
+    def test_ingest_json_upsert_fails(self, vector_index_instance, mock_embedding_manager, 
+                                      mock_qdrant_client_instance, mock_data_structure_checker, 
+                                      mock_log_wrapper):
+        """
+        Scenario 4: Upsert fails. `qdrant_client.upsert` raises error. `log_wrapper.error` called.
+        """
+        valid_data = [{"uid": "doc1", "text": "Text for document 1"}]
+        mock_embedding_manager.generate_embedding.return_value = [0.1] * 10
+        
+        original_error_message = "Qdrant upsert failed due to network issue"
+        mock_qdrant_client_instance.upsert.side_effect = Exception(original_error_message)
+        
+        with pytest.raises(Exception, match=original_error_message): # Ensure the original exception is re-raised
+            vector_index_instance.ingest_json(valid_data)
+            
+        mock_log_wrapper.error.assert_called_once_with(
+            "VectorIndex", "ingest_json", 
+            f"Failed to ingest documents into '{vector_index_instance.collection_name}'. Error: {original_error_message}"
+        )
+
+    def test_ingest_json_data_structure_validation_fails(
+        self, vector_index_instance, mock_data_structure_checker, 
+        mock_qdrant_client_instance, mock_log_wrapper
+    ):
+        """
+        Test that if data_structure_checker.validate fails, an error is logged and upsert is not called.
+        """
+        invalid_structured_data = [{"uid": 123, "text": "Bad UID type"}] # Example of invalid structure
+        from src.rag_core.domain.schema_checker import DataSchemaError # Import for raising
+        mock_data_structure_checker.validate.side_effect = DataSchemaError(details=["Invalid UID type"])
+
+        with pytest.raises(DataSchemaError): # Assuming DataSchemaError should propagate
+             vector_index_instance.ingest_json(invalid_structured_data)
+
+        mock_log_wrapper.error.assert_called_once_with(
+            "VectorIndex", "ingest_json",
+            "Data structure validation failed. Details: Invalid UID type"
+        )
+        mock_qdrant_client_instance.upsert.assert_not_called()
+
+class TestVectorIndexSearch:
+    @pytest.fixture
+    def vector_index_instance(self, mock_qdrant_client_class, mock_embedding_manager, 
+                              mock_data_structure_checker, mock_config_manager_settings):
+        return VectorIndex(
+            embedding_manager=mock_embedding_manager,
+            data_checker=mock_data_structure_checker
+        )
+
+    def test_search_success_no_filters(self, vector_index_instance, mock_qdrant_client_instance, 
+                                       mock_embedding_manager, mock_log_wrapper):
+        """
+        Scenario 1: Success, no filters.
+        `qdrant_client.search` returns mock `ScoredPoint`s.
+        Check `search` args (filter is `None`). Check formatted results.
+        """
+        query_text = "Search for this text"
+        query_vector = [0.5] * 10 # Example vector
+        k = 5
+        
+        mock_embedding_manager.generate_embedding.return_value = query_vector
+        
+        # mock_qdrant_client_instance.search is already set up in the main fixture
+        # to return two ScoredPoint mocks.
+        
+        results = vector_index_instance.search(query_text, k=k)
+        
+        mock_embedding_manager.generate_embedding.assert_called_once_with(query_text)
+        mock_qdrant_client_instance.search.assert_called_once_with(
+            collection_name=vector_index_instance.collection_name,
+            query_vector=query_vector,
+            query_filter=None, # Assert filter is None
+            limit=k,
+            with_payload=True,
+            with_vectors=True # Assuming default or standard practice
+        )
+        
+        assert len(results) == 2 # Based on mock_qdrant_client_instance fixture
+        assert results[0]['uid'] == "doc1"
+        assert results[0]['text'] == "Document 1 text"
+        assert results[0]['score'] == 0.9
+        assert 'vector' in results[0] # Check if vector is included
+        assert results[0]['orig_sid'] == "orig_doc1_sid"
+        assert results[0]['side'] == "default_side"
+
+
+    def test_search_success_with_filters(self, vector_index_instance, mock_qdrant_client_instance, 
+                                         mock_embedding_manager, mock_log_wrapper):
+        """
+        Scenario 2: Success, with filters.
+        Provide filters. Check `qdrant_client.search` called with `models.Filter`.
+        """
+        query_text = "Search with filters"
+        query_vector = [0.6] * 10
+        k = 3
+        filters = {"orig_sid": "specific_sid", "custom_field": "custom_value"}
+        
+        mock_embedding_manager.generate_embedding.return_value = query_vector
+        
+        results = vector_index_instance.search(query_text, k=k, filter_expr=filters)
+        
+        mock_embedding_manager.generate_embedding.assert_called_once_with(query_text)
+        
+        # Construct the expected filter structure
+        expected_qdrant_filter = models.Filter(
+            must=[
+                models.FieldCondition(key="orig_sid", match=models.MatchValue(value="specific_sid")),
+                models.FieldCondition(key="custom_field", match=models.MatchValue(value="custom_value"))
+            ]
+        )
+        
+        mock_qdrant_client_instance.search.assert_called_once_with(
+            collection_name=vector_index_instance.collection_name,
+            query_vector=query_vector,
+            query_filter=expected_qdrant_filter, # Assert filter structure
+            limit=k,
+            with_payload=True,
+            with_vectors=True
+        )
+        assert len(results) == 2 # Still using the default mock return for search
+
+    def test_search_fails(self, vector_index_instance, mock_qdrant_client_instance, 
+                          mock_embedding_manager, mock_log_wrapper):
+        """
+        Scenario 3: Search fails. `qdrant_client.search` raises error.
+        `log_wrapper.error` called, returns `[]`.
+        """
+        query_text = "Search that will fail"
+        query_vector = [0.7] * 10
+        k = 5
+        original_error_message = "Qdrant search connection timeout"
+        
+        mock_embedding_manager.generate_embedding.return_value = query_vector
+        mock_qdrant_client_instance.search.side_effect = Exception(original_error_message)
+        
+        results = vector_index_instance.search(query_text, k=k)
+        
+        assert results == []
+        mock_log_wrapper.error.assert_called_once_with(
+            "VectorIndex", "search", 
+            f"Error searching in collection '{vector_index_instance.collection_name}'. Error: {original_error_message}"
+        )
+
+    def test_search_embedding_fails(self, vector_index_instance, mock_qdrant_client_instance,
+                                   mock_embedding_manager, mock_log_wrapper):
+        """ Test search when embedding generation fails. """
+        query_text = "Search with failing embedding"
+        k = 3
+        original_embedding_error = "Embedding model not available"
+        mock_embedding_manager.generate_embedding.side_effect = Exception(original_embedding_error)
+
+        results = vector_index_instance.search(query_text, k=k)
+
+        assert results == []
+        mock_log_wrapper.error.assert_called_once_with(
+            "VectorIndex", "search",
+            f"Failed to generate embedding for query: '{query_text}'. Error: {original_embedding_error}"
+        )
+        mock_qdrant_client_instance.search.assert_not_called()
+
+@pytest.mark.asyncio
+class TestVectorIndexSearchAsync:
+    @pytest.fixture # Ensure this fixture is defined if not already, or use the one from TestVectorIndexSearch
+    def vector_index_instance(self, mock_qdrant_client_class, mock_embedding_manager, 
+                              mock_data_structure_checker, mock_config_manager_settings):
+        return VectorIndex(
+            embedding_manager=mock_embedding_manager,
+            data_checker=mock_data_structure_checker
+        )
+
+    async def test_search_async_successful_call(self, vector_index_instance, mocker):
+        """
+        Test successful async search call.
+        Mocks the synchronous `search` method.
+        """
+        query_text = "Async search query"
+        k = 5
+        filters = {"field": "value"}
+        expected_sync_result = [{"uid": "async_doc1", "text": "Async content", "score": 0.88}]
+        
+        # Mock the synchronous search method on the instance
+        mock_sync_search = mocker.patch.object(
+            vector_index_instance, 
+            'search', 
+            return_value=expected_sync_result
+        )
+        
+        result = await vector_index_instance.search_async(query_text, k=k, filter_expr=filters)
+        
+        mock_sync_search.assert_called_once_with(query_text, k, filters)
+        assert result == expected_sync_result
+
+    async def test_search_async_exception_in_sync_call(self, vector_index_instance, mocker, mock_log_wrapper):
+        """
+        Test exception propagation from synchronous search in async call.
+        """
+        query_text = "Async search causing error"
+        k = 3
+        original_exception = Exception("Error in sync search during async call")
+        
+        mocker.patch.object(
+            vector_index_instance,
+            'search',
+            side_effect=original_exception
+        )
+        
+        # The async wrapper in VectorIndex is expected to catch the exception, log it, and return [].
+        # This differs from some other async wrappers that might re-raise.
+        # Let's assume the VectorIndex.search_async is designed to be resilient and return empty on error.
+        # If it's supposed to re-raise, this test needs to change.
+        # Based on the provided source for search_async, it logs and returns [].
+        
+        result = await vector_index_instance.search_async(query_text, k=k)
+        
+        assert result == [] # Expect empty list on error as per VectorIndex.search_async implementation
+        mock_log_wrapper.error.assert_called_once_with(
+            "VectorIndex", "search_async",
+            f"Error during async search for query '{query_text}'. Error: {original_exception}"
+        )
+
+class TestVectorIndexRemoveDocument:
+    @pytest.fixture # Ensure this fixture is defined if not already
+    def vector_index_instance(self, mock_qdrant_client_class, mock_embedding_manager, 
+                              mock_data_structure_checker, mock_config_manager_settings):
+        return VectorIndex(
+            embedding_manager=mock_embedding_manager,
+            data_checker=mock_data_structure_checker
+        )
+
+    def test_remove_document_success(self, vector_index_instance, mock_qdrant_client_instance, mock_log_wrapper):
+        """
+        Scenario 1: Success. `qdrant_client.delete` called with filter for `orig_sid`.
+        """
+        orig_sid_to_remove = "doc_to_delete_orig_sid"
+        
+        vector_index_instance.remove_document(orig_sid_to_remove)
+        
+        expected_filter = models.Filter(
+            must=[
+                models.FieldCondition(key="orig_sid", match=models.MatchValue(value=orig_sid_to_remove))
+            ]
+        )
+        
+        mock_qdrant_client_instance.delete.assert_called_once_with(
+            collection_name=vector_index_instance.collection_name,
+            points_selector=expected_filter
+        )
+        mock_log_wrapper.info.assert_called_once_with(
+            "VectorIndex", "remove_document",
+            f"Successfully removed document with orig_sid '{orig_sid_to_remove}' from '{vector_index_instance.collection_name}'."
+        )
+
+    def test_remove_document_deletion_fails(self, vector_index_instance, mock_qdrant_client_instance, mock_log_wrapper):
+        """
+        Scenario 2: Deletion fails. `qdrant_client.delete` raises error. `log_wrapper.error` called.
+        """
+        orig_sid_to_remove = "doc_fail_delete_orig_sid"
+        original_error_message = "Qdrant delete operation failed"
+        mock_qdrant_client_instance.delete.side_effect = Exception(original_error_message)
+        
+        with pytest.raises(Exception, match=original_error_message): # Assuming error is re-raised
+            vector_index_instance.remove_document(orig_sid_to_remove)
+            
+        mock_log_wrapper.error.assert_called_once_with(
+            "VectorIndex", "remove_document",
+            f"Failed to remove document with orig_sid '{orig_sid_to_remove}' from '{vector_index_instance.collection_name}'. Error: {original_error_message}"
+        )
+
+class TestVectorIndexUpdateDocument:
+    @pytest.fixture # Ensure this fixture is defined if not already
+    def vector_index_instance(self, mock_qdrant_client_class, mock_embedding_manager, 
+                              mock_data_structure_checker, mock_config_manager_settings):
+        return VectorIndex(
+            embedding_manager=mock_embedding_manager,
+            data_checker=mock_data_structure_checker
+        )
+
+    def test_update_document_success(self, vector_index_instance, mock_qdrant_client_instance, 
+                                     mock_embedding_manager, mock_log_wrapper, mock_uuid5):
+        """
+        Scenario 1: Success. `embedding_manager.generate_embedding` called.
+        `qdrant_client.upsert` called with correct `PointStruct`.
+        """
+        doc_uid = "doc_to_update_uid"
+        doc_text = "Updated text for the document."
+        doc_payload = {"orig_sid": "orig_sid_updated", "side": "updated_side", "custom": "info"}
+        
+        expected_vector = [0.9, 0.8, 0.7]
+        mock_embedding_manager.generate_embedding.return_value = expected_vector
+        
+        vector_index_instance.update_document(doc_uid, doc_text, doc_payload)
+        
+        mock_embedding_manager.generate_embedding.assert_called_once_with(doc_text)
+        
+        expected_point_id = VectorIndex._uid_to_point_id(doc_uid)
+        expected_full_payload = {"uid": doc_uid, "text": doc_text, **doc_payload}
+        
+        # Check upsert call
+        mock_qdrant_client_instance.upsert.assert_called_once()
+        args, kwargs = mock_qdrant_client_instance.upsert.call_args
+        
+        assert kwargs['collection_name'] == vector_index_instance.collection_name
+        
+        points_arg = kwargs['points']
+        assert len(points_arg) == 1
+        
+        assert points_arg[0].id == expected_point_id
+        assert points_arg[0].vector == expected_vector
+        assert points_arg[0].payload == expected_full_payload
+        
+        mock_log_wrapper.info.assert_called_once_with(
+            "VectorIndex", "update_document",
+            f"Successfully updated document with uid '{doc_uid}' in '{vector_index_instance.collection_name}'."
+        )
+
+    def test_update_document_upsert_fails(self, vector_index_instance, mock_qdrant_client_instance, 
+                                          mock_embedding_manager, mock_log_wrapper):
+        """
+        Scenario 2: Update fails. `qdrant_client.upsert` raises error. `log_wrapper.error` called.
+        """
+        doc_uid = "doc_fail_update_uid"
+        doc_text = "Text for failing update."
+        doc_payload = {"orig_sid": "orig_sid_fail"}
+        
+        mock_embedding_manager.generate_embedding.return_value = [0.5] * 10
+        original_error_message = "Qdrant upsert failed during update"
+        mock_qdrant_client_instance.upsert.side_effect = Exception(original_error_message)
+        
+        with pytest.raises(Exception, match=original_error_message): # Assuming error is re-raised
+            vector_index_instance.update_document(doc_uid, doc_text, doc_payload)
+            
+        mock_log_wrapper.error.assert_called_once_with(
+            "VectorIndex", "update_document",
+            f"Failed to update document with uid '{doc_uid}' in '{vector_index_instance.collection_name}'. Error: {original_error_message}"
+        )
+
+    def test_update_document_embedding_fails(self, vector_index_instance, mock_qdrant_client_instance,
+                                             mock_embedding_manager, mock_log_wrapper):
+        """ Test update_document when embedding generation fails. """
+        doc_uid = "doc_update_embed_fail"
+        doc_text = "Text for embedding failure update"
+        doc_payload = {"orig_sid": "orig_sid_embed_fail"}
+        original_embedding_error = "Embedding service unavailable for update"
+        mock_embedding_manager.generate_embedding.side_effect = Exception(original_embedding_error)
+
+        with pytest.raises(Exception, match=original_embedding_error):
+            vector_index_instance.update_document(doc_uid, doc_text, doc_payload)
+
+        mock_log_wrapper.error.assert_called_once_with(
+            "VectorIndex", "update_document",
+            f"Failed to generate embedding for document uid '{doc_uid}'. Error: {original_embedding_error}"
+        )
+        mock_qdrant_client_instance.upsert.assert_not_called()
+
+class TestVectorIndexGetDocumentById:
+    @pytest.fixture # Ensure this fixture is defined if not already
+    def vector_index_instance(self, mock_qdrant_client_class, mock_embedding_manager, 
+                              mock_data_structure_checker, mock_config_manager_settings):
+        return VectorIndex(
+            embedding_manager=mock_embedding_manager,
+            data_checker=mock_data_structure_checker
+        )
+
+    def test_get_document_by_id_found(self, vector_index_instance, mock_qdrant_client_instance, mock_log_wrapper):
+        """
+        Scenario 1: Found. `qdrant_client.retrieve` returns mock `PointRecord`s.
+        Check `retrieve` args. Check formatted results (score 1.0).
+        """
+        doc_uid = "doc_to_get_uid"
+        expected_point_id = VectorIndex._uid_to_point_id(doc_uid)
+        
+        # mock_qdrant_client_instance.retrieve is already configured in the main fixture
+        # to return one PointRecord. Let's adjust its payload for clarity.
+        mock_retrieved_point = mock_qdrant_client_instance.retrieve.return_value[0]
+        mock_retrieved_point.id = expected_point_id # Ensure ID matches
+        mock_retrieved_point.payload = {
+            "uid": doc_uid, 
+            "text": "Retrieved document text for get_document_by_id",
+            "orig_sid": "orig_sid_get",
+            "side": "get_side"
+        }
+        mock_retrieved_point.vector = [0.1,0.2] # Example vector
+
+        results = vector_index_instance.get_document_by_id(doc_uid)
+        
+        mock_qdrant_client_instance.retrieve.assert_called_once_with(
+            collection_name=vector_index_instance.collection_name,
+            ids=[expected_point_id],
+            with_payload=True,
+            with_vectors=True
+        )
+        
+        assert len(results) == 1
+        assert results[0]['uid'] == doc_uid
+        assert results[0]['text'] == "Retrieved document text for get_document_by_id"
+        assert results[0]['score'] == 1.0 # Score should be 1.0 for direct retrieval
+        assert results[0]['vector'] == [0.1,0.2]
+        assert results[0]['orig_sid'] == "orig_sid_get"
+        assert results[0]['side'] == "get_side"
+
+    def test_get_document_by_id_not_found(self, vector_index_instance, mock_qdrant_client_instance, mock_log_wrapper):
+        """
+        Scenario 2: Not found. `qdrant_client.retrieve` returns `[]`. Result is `[]`.
+        """
+        doc_uid = "doc_not_found_uid"
+        expected_point_id = VectorIndex._uid_to_point_id(doc_uid)
+        
+        mock_qdrant_client_instance.retrieve.return_value = [] # Simulate not found
+        
+        results = vector_index_instance.get_document_by_id(doc_uid)
+        
+        mock_qdrant_client_instance.retrieve.assert_called_once_with(
+            collection_name=vector_index_instance.collection_name,
+            ids=[expected_point_id],
+            with_payload=True,
+            with_vectors=True
+        )
+        assert results == []
+        # No error log should be called for a simple "not found" case.
+        # log_wrapper.info might be called if there was specific logging for not found, but not error.
+        mock_log_wrapper.error.assert_not_called()
+
+
+    def test_get_document_by_id_retrieve_fails(self, vector_index_instance, mock_qdrant_client_instance, mock_log_wrapper):
+        """
+        Scenario 3: Retrieve fails. `qdrant_client.retrieve` raises error.
+        `log_wrapper.error` called, returns `[]`.
+        """
+        doc_uid = "doc_retrieve_fail_uid"
+        expected_point_id = VectorIndex._uid_to_point_id(doc_uid)
+        original_error_message = "Qdrant retrieve operation failed"
+        
+        mock_qdrant_client_instance.retrieve.side_effect = Exception(original_error_message)
+        
+        results = vector_index_instance.get_document_by_id(doc_uid)
+        
+        mock_qdrant_client_instance.retrieve.assert_called_once_with(
+            collection_name=vector_index_instance.collection_name,
+            ids=[expected_point_id],
+            with_payload=True,
+            with_vectors=True
+        )
+        assert results == []
+        mock_log_wrapper.error.assert_called_once_with(
+            "VectorIndex", "get_document_by_id",
+            f"Error retrieving document with uid '{doc_uid}' (point_id '{expected_point_id}') from '{vector_index_instance.collection_name}'. Error: {original_error_message}"
+        )
+
+# End of test file.

--- a/tests/interfaces/test_cli_main.py
+++ b/tests/interfaces/test_cli_main.py
@@ -1,0 +1,250 @@
+import pytest
+import json
+import os
+from unittest.mock import MagicMock, mock_open, patch
+
+# Import the functions to be tested from cli_main
+from src.interfaces.cli_main import load_json_file, setup_core
+
+# Import classes that will be mocked (for type hinting and spec if needed)
+from src.rag_core.infrastructure.embedding import EmbeddingManager
+from src.rag_core.domain.schema_checker import DataStructureChecker
+from qdrant_client import QdrantClient
+from src.rag_core.infrastructure.vector_store import VectorIndex
+from src.rag_core.infrastructure.llm.llm_manager import LLMManager
+from src.rag_core.infrastructure.llm.openai_adapter import OpenAIAdapter
+from src.rag_core.infrastructure.llm.local_llama_adapter import LocalLlamaAdapter
+
+
+# --- Fixtures ---
+
+@pytest.fixture
+def mock_log_wrapper_cli(mocker):
+    """Mocks log_wrapper used in cli_main.py."""
+    return mocker.patch('src.interfaces.cli_main.log_wrapper')
+
+# --- Tests for load_json_file ---
+
+class TestLoadJsonFile:
+    def test_load_json_file_successful(self, mocker, mock_log_wrapper_cli):
+        """Scenario 1: Successful load."""
+        file_path = "dummy.json"
+        json_content_str = '{"key": "value"}'
+        expected_data = {"key": "value"}
+
+        m = mock_open(read_data=json_content_str)
+        mocker.patch('builtins.open', m)
+        
+        # Mock json.load within the context of src.interfaces.cli_main
+        mock_json_load = mocker.patch('src.interfaces.cli_main.json.load', return_value=expected_data)
+
+        result = load_json_file(file_path)
+
+        m.assert_called_once_with(file_path, 'r', encoding='utf-8')
+        mock_json_load.assert_called_once_with(m()) # m() is the file handle
+        assert result == expected_data
+        mock_log_wrapper_cli.error.assert_not_called()
+
+    def test_load_json_file_not_found_error(self, mocker, mock_log_wrapper_cli):
+        """Scenario 2: FileNotFoundError."""
+        file_path = "nonexistent.json"
+        
+        mocker.patch('builtins.open', side_effect=FileNotFoundError(f"No such file: {file_path}"))
+
+        with pytest.raises(FileNotFoundError):
+            load_json_file(file_path)
+        
+        mock_log_wrapper_cli.error.assert_called_once_with(
+            "load_json_file", # module_name (derived from func name)
+            "load_json_file", # func_name
+            f"File not found: {file_path}"
+        )
+
+    def test_load_json_file_decode_error(self, mocker, mock_log_wrapper_cli):
+        """Scenario 3: json.JSONDecodeError."""
+        file_path = "bad.json"
+        invalid_json_str = "invalid json"
+
+        m = mock_open(read_data=invalid_json_str)
+        mocker.patch('builtins.open', m)
+        
+        # Mock json.load to raise JSONDecodeError
+        # The error instance needs 'msg', 'doc', 'pos' arguments for standard representation
+        decode_error = json.JSONDecodeError("Expecting value", invalid_json_str, 0)
+        mock_json_load = mocker.patch('src.interfaces.cli_main.json.load', side_effect=decode_error)
+
+        with pytest.raises(json.JSONDecodeError):
+            load_json_file(file_path)
+        
+        m.assert_called_once_with(file_path, 'r', encoding='utf-8')
+        mock_json_load.assert_called_once_with(m())
+        mock_log_wrapper_cli.error.assert_called_once_with(
+            "load_json_file", # module_name
+            "load_json_file", # func_name
+            f"Error decoding JSON from file {file_path}: Expecting value: line 1 column 1 (char 0)"
+        )
+
+# --- Tests for setup_core ---
+
+@pytest.fixture
+def mock_config_manager_for_setup_core(mocker):
+    """Mocks config_manager and its nested settings for setup_core."""
+    mock_cfg_mgr = MagicMock()
+    
+    # APIKeysConfig
+    mock_cfg_mgr.settings.api_keys.openai = "test_openai_key_from_config"
+    
+    # EmbeddingConfig
+    mock_cfg_mgr.settings.embedding.model = "text-embedding-ada-002"
+    
+    # VectorDBConfig
+    mock_cfg_mgr.settings.vector_db.collection = "default_collection"
+    mock_cfg_mgr.settings.vector_db.vector_size = 1536
+    mock_cfg_mgr.settings.vector_db.qdrant_host = "qdrant_test_host"
+    mock_cfg_mgr.settings.vector_db.qdrant_port = 1234
+    # For QdrantClient, we need url or host/port. The code uses host/port if url is default.
+    # Let's assume default url and host/port are used.
+    mock_cfg_mgr.settings.vector_db.url = "http://localhost:6333" # Default, so host/port will be used
+
+    # LLMConfig (for OpenAIAdapter)
+    mock_cfg_mgr.settings.llm.model = "gpt-3.5-turbo-config"
+    mock_cfg_mgr.settings.llm.temperature = 0.75
+    mock_cfg_mgr.settings.llm.max_tokens = 2048
+    
+    # LocalLlamaConfig (specific for LocalLlamaAdapter)
+    # Assuming LocalLlamaAdapter takes these from config_manager.settings.llm as well,
+    # or has its own section. The prompt implies it uses fixed "models/llama.bin".
+    # The actual LocalLlamaAdapter in the codebase takes model_path, temperature, max_tokens.
+    # Let's assume these map from a 'local_llama' section or similar if different from 'llm'.
+    # For simplicity, let's assume it also uses settings.llm for temp/max_tokens and has a fixed path.
+    # Or, if setup_core uses a dedicated config path for llama_model_path:
+    mock_cfg_mgr.settings.local_llama.model_path = "config_path/to/llama.bin"
+    mock_cfg_mgr.settings.local_llama.temperature = 0.6
+    mock_cfg_mgr.settings.local_llama.max_tokens = 1024
+
+
+    mocker.patch('src.interfaces.cli_main.config_manager', mock_cfg_mgr)
+    return mock_cfg_mgr
+
+@pytest.fixture
+def mock_embedding_manager_class(mocker):
+    instance = MagicMock(spec=EmbeddingManager)
+    return mocker.patch('src.interfaces.cli_main.EmbeddingManager', return_value=instance), instance
+
+@pytest.fixture
+def mock_data_structure_checker_class(mocker):
+    instance = MagicMock(spec=DataStructureChecker)
+    return mocker.patch('src.interfaces.cli_main.DataStructureChecker', return_value=instance), instance
+
+@pytest.fixture
+def mock_qdrant_client_class_cli(mocker): # Renamed to avoid conflict if used elsewhere
+    instance = MagicMock(spec=QdrantClient)
+    return mocker.patch('src.interfaces.cli_main.QdrantClient', return_value=instance), instance
+
+@pytest.fixture
+def mock_vector_index_class(mocker):
+    instance = MagicMock(spec=VectorIndex)
+    return mocker.patch('src.interfaces.cli_main.VectorIndex', return_value=instance), instance
+
+@pytest.fixture
+def mock_llm_manager_class(mocker):
+    instance = MagicMock(spec=LLMManager)
+    instance.register_adapter = MagicMock()
+    instance.set_default_adapter = MagicMock()
+    return mocker.patch('src.interfaces.cli_main.LLMManager', return_value=instance), instance
+
+@pytest.fixture
+def mock_openai_adapter_class(mocker):
+    instance = MagicMock(spec=OpenAIAdapter)
+    return mocker.patch('src.interfaces.cli_main.OpenAIAdapter', return_value=instance), instance
+
+@pytest.fixture
+def mock_local_llama_adapter_class(mocker):
+    instance = MagicMock(spec=LocalLlamaAdapter)
+    return mocker.patch('src.interfaces.cli_main.LocalLlamaAdapter', return_value=instance), instance
+
+
+class TestSetupCore:
+    def test_setup_core_initialization_and_wiring(
+        self,
+        mock_config_manager_for_setup_core, # Provides settings
+        mock_embedding_manager_class,
+        mock_data_structure_checker_class,
+        mock_qdrant_client_class_cli,
+        mock_vector_index_class,
+        mock_llm_manager_class,
+        mock_openai_adapter_class,
+        mock_local_llama_adapter_class,
+        mock_log_wrapper_cli # To ensure it's available if setup_core logs
+    ):
+        cfg_settings = mock_config_manager_for_setup_core.settings
+        
+        # Get mocked classes and their instances from fixtures
+        MockEmbeddingManager, embed_mgr_instance = mock_embedding_manager_class
+        MockDataStructureChecker, checker_instance = mock_data_structure_checker_class
+        MockQdrantClient, qdrant_client_instance = mock_qdrant_client_class_cli
+        MockVectorIndex, vector_index_instance = mock_vector_index_class
+        MockLLMManager, llm_mgr_instance = mock_llm_manager_class
+        MockOpenAIAdapter, openai_adapter_instance = mock_openai_adapter_class
+        MockLocalLlamaAdapter, local_llama_adapter_instance = mock_local_llama_adapter_class
+
+        # Call the function to test
+        result_embed_mgr, result_vector_index, result_llm_mgr = setup_core()
+
+        # Assertions
+        MockEmbeddingManager.assert_called_once_with(
+            openai_api_key=cfg_settings.api_keys.openai,
+            embedding_model_name=cfg_settings.embedding.model
+        )
+        MockDataStructureChecker.assert_called_once_with()
+        
+        # QdrantClient uses host/port if url is default
+        # Assuming default URL scenario based on how QdrantClient is typically used in VectorIndex
+        MockQdrantClient.assert_called_once_with(
+            host=cfg_settings.vector_db.qdrant_host,
+            port=cfg_settings.vector_db.qdrant_port
+        )
+        # Or if it used URL:
+        # MockQdrantClient.assert_called_once_with(url=cfg_settings.vector_db.url)
+
+
+        MockVectorIndex.assert_called_once_with(
+            embedding_manager=embed_mgr_instance,
+            data_checker=checker_instance,
+            qdrant_client=qdrant_client_instance, # The instance returned by MockQdrantClient
+            collection_name=cfg_settings.vector_db.collection,
+            vector_size=cfg_settings.vector_db.vector_size
+        )
+        
+        MockLLMManager.assert_called_once_with()
+        
+        MockOpenAIAdapter.assert_called_once_with(
+            api_key=cfg_settings.api_keys.openai,
+            model_name=cfg_settings.llm.model,
+            temperature=cfg_settings.llm.temperature,
+            max_tokens=cfg_settings.llm.max_tokens
+        )
+        
+        # The prompt says LocalLlamaAdapter uses "models/llama.bin" fixed path
+        # But the fixture mock_config_manager_for_setup_core provides a config path.
+        # Let's assume setup_core uses the fixed path as per prompt for this test.
+        # If setup_core is changed to use config, this assertion needs to change.
+        fixed_llama_model_path = "models/llama.bin" 
+        MockLocalLlamaAdapter.assert_called_once_with(
+            # model_path=cfg_settings.local_llama.model_path, # If using config path
+            model_path=fixed_llama_model_path, # As per prompt's specific instruction for setup_core
+            temperature=cfg_settings.local_llama.temperature, # Assuming these come from a specific 'local_llama' config section
+            max_tokens=cfg_settings.local_llama.max_tokens
+        )
+
+        llm_mgr_instance.register_adapter.assert_any_call("openai", openai_adapter_instance)
+        llm_mgr_instance.register_adapter.assert_any_call("llama", local_llama_adapter_instance)
+        assert llm_mgr_instance.register_adapter.call_count == 2
+        
+        llm_mgr_instance.set_default_adapter.assert_called_once_with("openai")
+        
+        assert result_embed_mgr is embed_mgr_instance
+        assert result_vector_index is vector_index_instance
+        assert result_llm_mgr is llm_mgr_instance
+
+# End of test file

--- a/tests/utils/test_blacklist_manager.py
+++ b/tests/utils/test_blacklist_manager.py
@@ -1,0 +1,88 @@
+import pytest
+from src.rag_core.utils.blacklist import BlacklistManager
+
+class TestBlacklistManagerInit:
+    def test_init_no_blacklist_db_provided(self):
+        """Scenario 1: No blacklist_db provided."""
+        manager = BlacklistManager()
+        assert manager.blacklist_db == []
+
+    def test_init_blacklist_db_provided(self):
+        """Scenario 2: blacklist_db provided."""
+        my_list = ["item1", "item2"]
+        manager = BlacklistManager(blacklist_db=my_list)
+        assert manager.blacklist_db is my_list # Check for identity
+
+# --- Test Cases for check_urls ---
+CHECK_URLS_TEST_CASES = [
+    # Scenario 1: Empty blacklist
+    ([], "http://example.com", [], "empty_blacklist"),
+    # Scenario 2: No matches
+    (["http://blocked.com"], "http://allowed.com", [], "no_matches"),
+    # Scenario 3: One match
+    (["http://blocked.com"], "visit http://blocked.com now", ["http://blocked.com"], "one_match"),
+    # Scenario 4: Multiple matches
+    (["url1.com", "site2.org"], "check url1.com and site2.org", ["url1.com", "site2.org"], "multiple_matches"),
+    # Scenario 5: Partial match (substring)
+    (["example.com"], "goto http://example.com/path", ["example.com"], "partial_match_substring"),
+    # Scenario 6: Empty text input
+    (["http://blocked.com"], "", [], "empty_text_input"),
+    # Scenario 7: Case sensitivity - no match
+    (["Domain.com"], "check domain.com", [], "case_sensitive_no_match"),
+    # Scenario 7: Case sensitivity - match
+    (["Domain.com"], "check Domain.com", ["Domain.com"], "case_sensitive_match"),
+    # Additional: URL in blacklist, no http prefix in text
+    (["example.com"], "Visit example.com today", ["example.com"], "no_http_prefix_in_text"),
+    # Additional: Multiple occurrences of the same blacklisted URL
+    (["bad.com"], "bad.com is bad.com", ["bad.com", "bad.com"], "multiple_occurrences_same_url"),
+]
+
+@pytest.mark.parametrize("blacklist, text, expected, test_id", CHECK_URLS_TEST_CASES)
+def test_check_urls(blacklist, text, expected, test_id):
+    manager = BlacklistManager(blacklist_db=blacklist)
+    result = manager.check_urls(text)
+    if test_id == "multiple_matches" or test_id == "multiple_occurrences_same_url": # Order might not be guaranteed by findall
+        assert set(result) == set(expected), f"Test ID: {test_id}"
+    else:
+        assert result == expected, f"Test ID: {test_id}"
+
+# --- Test Cases for check_line_ids ---
+CHECK_LINE_IDS_TEST_CASES = [
+    # Scenario 1: Empty blacklist
+    ([], "id: user123", [], "empty_blacklist"),
+    # Scenario 2: No matches
+    (["official_id"], "my id is test_id", [], "no_matches"),
+    # Scenario 3: One match
+    (["user456"], "contact user456 for info", ["user456"], "one_match"),
+    # Scenario 4: Multiple matches
+    (["id_A", "id_B"], "users id_A and id_B are here", ["id_A", "id_B"], "multiple_matches"),
+    # Scenario 5: Partial match (substring) - current implementation is exact word match due to \b
+    # If BlacklistManager uses regex without word boundaries for line IDs, this test would change.
+    # Assuming current implementation (from problem description) implies exact word match for IDs.
+    # Let's test based on the idea that it finds the ID if it's present as a "word".
+    (["admin"], "line id: admin_user", ["admin"], "partial_match_substring_as_word_boundary"), # "admin" is found in "admin_user"
+    (["admin"], "line id: admin", ["admin"], "exact_match_as_word"),
+    (["admin"], "line id: myadmin", ["admin"], "prefix_match_as_word_boundary"), # "admin" is found in "myadmin"
+    (["admin"], "line id: superadmin", ["admin"], "suffix_match_as_word_boundary"), # "admin" is found in "superadmin"
+    (["admin"], "administrator", ["admin"], "substring_in_longer_word"), # "admin" is found in "administrator"
+    # Scenario 6: Empty text input
+    (["user789"], "", [], "empty_text_input"),
+    # Scenario 7: Case sensitivity - no match
+    (["UserID"], "check userid", [], "case_sensitive_no_match"),
+    # Scenario 7: Case sensitivity - match
+    (["UserID"], "check UserID", ["UserID"], "case_sensitive_match"),
+    # Additional: Multiple occurrences of the same blacklisted ID
+    (["idXYZ"], "idXYZ is repeated idXYZ", ["idXYZ", "idXYZ"], "multiple_occurrences_same_id"),
+]
+
+@pytest.mark.parametrize("blacklist, text, expected, test_id", CHECK_LINE_IDS_TEST_CASES)
+def test_check_line_ids(blacklist, text, expected, test_id):
+    manager = BlacklistManager(blacklist_db=blacklist)
+    result = manager.check_line_ids(text)
+    # For line IDs, re.findall might return them in order, but using set for safety if order is not guaranteed.
+    if "multiple_matches" in test_id or "multiple_occurrences" in test_id:
+        assert set(result) == set(expected), f"Test ID: {test_id}"
+    else:
+        assert result == expected, f"Test ID: {test_id}"
+
+# End of test file

--- a/tests/utils/test_data_structure_checker.py
+++ b/tests/utils/test_data_structure_checker.py
@@ -1,0 +1,122 @@
+import pytest
+from rag_core.utils.data_structure_checker import DataStructureChecker
+from rag_core.exceptions import DataStructureError
+
+# Test cases for check_structure
+# Each tuple: (data_to_check, expected_structure, expected_to_pass, error_message_substring_if_fail)
+
+VALID_LIST_OF_DICTS = [
+    {"uid": "a", "text": "text_a", "score": 0.1},
+    {"uid": "b", "text": "text_b", "score": 0.2}
+]
+INVALID_TYPE_IN_LIST = [
+    {"uid": "a", "text": "text_a", "score": 0.1},
+    "not_a_dict"
+]
+MISSING_KEY_IN_DICT = [
+    {"uid": "a", "text": "text_a", "score": 0.1},
+    {"uid": "b", "text_content": "text_b", "score": 0.2} # 'text' key is missing
+]
+WRONG_VALUE_TYPE_IN_DICT = [
+    {"uid": "a", "text": "text_a", "score": "not_a_float"}, # score should be float
+    {"uid": "b", "text": "text_b", "score": 0.2}
+]
+EMPTY_LIST_VALID = []
+
+# Expected structures
+EXPECTED_DOC_STRUCTURE = {
+    "uid": str,
+    "text": str,
+    "score": float
+}
+
+test_cases_check_structure = [
+    # Positive cases
+    (VALID_LIST_OF_DICTS, [EXPECTED_DOC_STRUCTURE], True, None),
+    (EMPTY_LIST_VALID, [EXPECTED_DOC_STRUCTURE], True, None), # Empty list is valid against list of dicts
+    ({"name": "test", "version": 1.0}, {"name": str, "version": float}, True, None), # Single dict
+    (VALID_LIST_OF_DICTS[0], EXPECTED_DOC_STRUCTURE, True, None), # Single dict from list
+
+    # Negative cases: List checks
+    ("not_a_list", [EXPECTED_DOC_STRUCTURE], False, "Data is not a list"),
+    (INVALID_TYPE_IN_LIST, [EXPECTED_DOC_STRUCTURE], False, "Item at index 1 is not a dictionary"),
+    (MISSING_KEY_IN_DICT, [EXPECTED_DOC_STRUCTURE], False, "Missing key 'text' in dictionary at index 1"),
+    (WRONG_VALUE_TYPE_IN_DICT, [EXPECTED_DOC_STRUCTURE], False, "Value for key 'score' in dictionary at index 0 is not of type float"),
+    
+    # Negative cases: Dict checks
+    ({"name": "test", "version": "1"}, {"name": str, "version": float}, False, "Value for key 'version' is not of type float"),
+    ({"name": "test"}, {"name": str, "version": float}, False, "Missing key 'version'"),
+    ("not_a_dict", {"name": str}, False, "Data is not a dictionary"),
+    (None, {"name": str}, False, "Data is not a dictionary"),
+    (None, [EXPECTED_DOC_STRUCTURE], False, "Data is not a list"),
+
+    # Nested Structures (Optional, can add if checker supports it, for now assume flat)
+    # Example: ({"user": {"name": "John", "age": 30}}, {"user": {"name": str, "age": int}}, True, None),
+    # Example: ({"user": {"name": "John", "age": "30"}}, {"user": {"name": str, "age": int}}, False, "Value for key 'age' in nested dict 'user' is not of type int"),
+]
+
+@pytest.mark.parametrize("data, structure, should_pass, error_msg_substr", test_cases_check_structure)
+def test_check_structure(data, structure, should_pass, error_msg_substr):
+    if should_pass:
+        try:
+            DataStructureChecker.check_structure(data, structure)
+        except DataStructureError as e:
+            pytest.fail(f"check_structure raised DataStructureError unexpectedly: {e}")
+    else:
+        with pytest.raises(DataStructureError) as excinfo:
+            DataStructureChecker.check_structure(data, structure)
+        if error_msg_substr:
+            assert error_msg_substr in str(excinfo.value), \
+                f"Expected error message to contain '{error_msg_substr}', but got '{str(excinfo.value)}'"
+
+# Test cases for check_list_of_dicts (specific helper, if it has unique logic not covered by check_structure)
+# For now, check_structure with [EXPECTED_DOC_STRUCTURE] covers most list of dicts scenarios.
+# If check_list_of_dicts has additional specific checks (e.g., non-empty list, uniform dicts beyond types), add them here.
+
+# Example of how one might test a specific method if it existed and had unique logic:
+# def test_check_list_of_dicts_custom_scenario():
+#     with pytest.raises(DataStructureError, match="some specific message"):
+#         DataStructureChecker.check_list_of_dicts([{"key": 1}, {"key": "string"}], {"key": int}, ensure_uniform_keys=True)
+
+
+# Test cases for specific error messages or complex scenarios can be added as individual test functions if needed.
+def test_check_structure_detailed_error_for_wrong_type_in_list():
+    data = [{"key": "value"}, "string_element", {"key": "value2"}]
+    structure = [{"key": str}]
+    with pytest.raises(DataStructureError) as excinfo:
+        DataStructureChecker.check_structure(data, structure)
+    assert "Item at index 1 is not a dictionary" in str(excinfo.value)
+    assert "Expected a dictionary, but got <class 'str'>" in str(excinfo.value)
+
+def test_check_structure_detailed_error_for_missing_key():
+    data = [{"key1": "value1"}, {"key2": "value2"}] # key1 is missing in second dict
+    structure = [{"key1": str}]
+    with pytest.raises(DataStructureError) as excinfo:
+        DataStructureChecker.check_structure(data, structure)
+    assert "Missing key 'key1' in dictionary at index 1" in str(excinfo.value)
+
+def test_check_structure_detailed_error_for_wrong_value_type():
+    data = [{"key1": "value1", "key2": 123}] # key2 should be str
+    structure = {"key1": str, "key2": str}
+    with pytest.raises(DataStructureError) as excinfo:
+        DataStructureChecker.check_structure(data, structure)
+    assert "Value for key 'key2' is not of type str" in str(excinfo.value)
+    assert "Expected type <class 'str'>, but got <class 'int'>" in str(excinfo.value)
+
+def test_check_structure_with_none_data_and_list_structure():
+    """Test case for when data is None and structure expects a list."""
+    data = None
+    structure = [{"key1": str}]  # Expects a list of dicts
+    with pytest.raises(DataStructureError) as excinfo:
+        DataStructureChecker.check_structure(data, structure)
+    assert "Data is not a list. Expected a list, but got <class 'NoneType'>" in str(excinfo.value)
+
+def test_check_structure_with_none_data_and_dict_structure():
+    """Test case for when data is None and structure expects a dict."""
+    data = None
+    structure = {"key1": str}  # Expects a dict
+    with pytest.raises(DataStructureError) as excinfo:
+        DataStructureChecker.check_structure(data, structure)
+    assert "Data is not a dictionary. Expected a dictionary, but got <class 'NoneType'>" in str(excinfo.value)
+
+# End of test file.

--- a/tests/utils/test_logging.py
+++ b/tests/utils/test_logging.py
@@ -1,0 +1,216 @@
+import pytest
+import importlib
+import os
+from unittest.mock import MagicMock, patch
+
+# Initial import of the module to be tested. This will be reloaded in tests.
+import src.utils.logging
+
+# --- Fixtures ---
+
+@pytest.fixture
+def mock_logger(mocker):
+    """Mocks src.utils.logging.logger and its methods."""
+    logger_instance = MagicMock()
+    logger_instance.add = MagicMock()
+    logger_instance.critical = MagicMock()
+    logger_instance.error = MagicMock()
+    logger_instance.warning = MagicMock()
+    logger_instance.info = MagicMock()
+    logger_instance.debug = MagicMock()
+    mocker.patch('src.utils.logging.logger', logger_instance)
+    return logger_instance
+
+@pytest.fixture
+def mock_system_settings(mocker):
+    """Mocks src.utils.logging.config_manager.settings.system."""
+    # This mock will be configured per test for is_debug
+    system_settings_mock = MagicMock() 
+    mocker.patch('src.utils.logging.config_manager.settings.system', system_settings_mock)
+    return system_settings_mock
+
+@pytest.fixture
+def reloaded_logging_module(mock_logger, mock_system_settings):
+    """
+    Fixture to reload the logging module after mocks for logger and system_settings are in place.
+    This ensures that class variables like IS_DEBUG are set based on the mocked values.
+    It returns the reloaded module.
+    """
+    # Mocks (mock_logger, mock_system_settings) are already active due to pytest fixture order.
+    # This fixture's job is to ensure the module is reloaded using those mocks.
+    reloaded_module = importlib.reload(src.utils.logging)
+    return reloaded_module
+
+
+# --- Test get_caller ---
+
+@pytest.mark.parametrize("input_path, expected_filename", [
+    ("/path/to/some_file.py", "some_file.py"),
+    ("another_file.py", "another_file.py"),
+    ("no_extension", "no_extension"),
+    ("/path/to/deep/nested/module.py", "module.py"),
+    ("", "") # Edge case: empty path
+])
+def test_get_caller(input_path, expected_filename, reloaded_logging_module):
+    # get_caller is a static method on log_wrapper in the reloaded module
+    result = reloaded_logging_module.log_wrapper.get_caller(input_path)
+    assert result == expected_filename
+
+# --- Test compose_msg ---
+
+@pytest.mark.parametrize("module, func, msg, expected_composed_msg", [
+    ("ModuleA", "FunctionB", "Log C", "module: [ModuleA] func: [FunctionB] | Log C"),
+    ("Main", "run", "Process started", "module: [Main] func: [run] | Process started"),
+    ("", "", "", "module: [] func: [] | "), # Edge case: empty inputs
+])
+def test_compose_msg(module, func, msg, expected_composed_msg, reloaded_logging_module):
+    # compose_msg is a static method on log_wrapper in the reloaded module
+    result = reloaded_logging_module.log_wrapper.compose_msg(module, func, msg)
+    assert result == expected_composed_msg
+
+# --- Test log_wrapper standard logging methods ---
+
+@pytest.mark.parametrize("log_method_name, logger_method_name", [
+    ("critical", "critical"),
+    ("error", "error"),
+    ("warning", "warning"),
+    ("info", "info"),
+])
+def test_log_wrapper_standard_methods(
+    log_method_name, logger_method_name, mock_logger, reloaded_logging_module
+):
+    """
+    Tests critical, error, warning, info methods of log_wrapper.
+    """
+    module_name = "TestModule"
+    func_name = "test_function"
+    message = f"{log_method_name} message"
+    expected_composed_message = f"module: [{module_name}] func: [{func_name}] | {message}"
+
+    # Get the static method from the reloaded log_wrapper class
+    log_method_to_call = getattr(reloaded_logging_module.log_wrapper, log_method_name)
+    log_method_to_call(module_name, func_name, message)
+
+    # Get the corresponding mock method from the globally patched mock_logger
+    mocked_logger_method = getattr(mock_logger, logger_method_name)
+    mocked_logger_method.assert_called_once_with(expected_composed_message)
+
+    # Ensure other log levels were not called
+    for other_method_name in ["critical", "error", "warning", "info", "debug"]:
+        if other_method_name != logger_method_name:
+            other_mocked_method = getattr(mock_logger, other_method_name)
+            other_mocked_method.assert_not_called()
+
+
+# --- Test log_wrapper.debug (conditional) ---
+
+def test_log_wrapper_debug_when_is_debug_true(mock_logger, mock_system_settings, reloaded_logging_module):
+    """
+    Test log_wrapper.debug when IS_DEBUG is True.
+    """
+    mock_system_settings.is_debug = True # Configure the mock
+    
+    # Reload the module to pick up the new mock_system_settings.is_debug value
+    # The reloaded_logging_module fixture already does this, but if we change mock_system_settings
+    # *after* it has run, we might need to reload again.
+    # The fixture order should handle this: mock_system_settings runs, then reloaded_logging_module runs.
+    # So, this explicit reload might be redundant if IS_DEBUG is set before reloaded_logging_module is resolved.
+    # For safety and clarity, especially if is_debug was changed after initial reload:
+    reloaded_module_after_set = importlib.reload(src.utils.logging)
+
+
+    module_name = "DebugModule"
+    func_name = "debug_func"
+    message = "This is a debug message"
+    expected_composed_message = f"module: [{module_name}] func: [{func_name}] | {message}"
+
+    reloaded_module_after_set.log_wrapper.debug(module_name, func_name, message)
+    
+    mock_logger.debug.assert_called_once_with(expected_composed_message)
+
+def test_log_wrapper_debug_when_is_debug_false(mock_logger, mock_system_settings, reloaded_logging_module):
+    """
+    Test log_wrapper.debug when IS_DEBUG is False.
+    """
+    mock_system_settings.is_debug = False # Configure the mock
+
+    # Reload the module to pick up the new mock_system_settings.is_debug value.
+    # Similar to the true case, reloaded_logging_module should handle initial setup.
+    # For safety if this test runs after the True case and state needs to be reset based on new mock value:
+    reloaded_module_after_set = importlib.reload(src.utils.logging)
+
+    module_name = "DebugModule"
+    func_name = "debug_func"
+    message = "This is a debug message (should not appear)"
+
+    reloaded_module_after_set.log_wrapper.debug(module_name, func_name, message)
+    
+    mock_logger.debug.assert_not_called()
+
+
+# --- (Optional) Test module-level logger.add calls ---
+# These tests are more complex due to when logger.add is called (at module import time).
+# They require patching before the module is loaded or very careful reloading.
+
+@patch('src.utils.logging.os.makedirs')
+@patch('src.utils.logging.os.path.exists')
+def test_logger_add_calls_on_module_load(mock_path_exists, mock_makedirs, mocker):
+    """
+    Tests that logger.add is called correctly when the logging module is imported/reloaded.
+    This requires careful management of mocks *before* the module is (re)loaded.
+    """
+    # Ensure mocks are set up *before* the critical import/reload
+    mock_path_exists.return_value = False # Simulate log directory does not exist
+
+    # Mock the logger that will be used by the module when it's reloaded
+    # This needs to be the same mock object that the module `src.utils.logging` will see.
+    # The `mock_logger` fixture patches 'src.utils.logging.logger'.
+    # When we reload src.utils.logging, it will pick up this patched logger.
+    
+    # We need to ensure the logger is mocked *before* the reload operation that triggers `logger.add`.
+    # The `mock_logger` fixture handles patching `src.utils.logging.logger`.
+    # We will call `importlib.reload` within the test.
+    
+    local_mock_logger = MagicMock()
+    local_mock_logger.add = MagicMock() # Crucial part for this test
+    mocker.patch('src.utils.logging.logger', local_mock_logger)
+
+
+    # Configure system.is_debug for this specific reload context if necessary for logger.add calls
+    # Assuming default behavior of logger.add isn't affected by IS_DEBUG for this test
+    mock_system_settings_for_add = MagicMock()
+    mock_system_settings_for_add.is_debug = False # Or True, depending on what logic logger.add might have
+    mocker.patch('src.utils.logging.config_manager.settings.system', mock_system_settings_for_add)
+
+
+    # Reload the module to trigger the logger.add calls
+    importlib.reload(src.utils.logging)
+
+    # Assertions
+    mock_makedirs.assert_called_once_with(os.path.join(src.utils.logging.PROJECT_ROOT, "logs"), exist_ok=True)
+    
+    # Expected calls to logger.add
+    # Call 1: Error log file
+    log_file_error = os.path.join(src.utils.logging.PROJECT_ROOT, "logs", "error.log")
+    local_mock_logger.add.assert_any_call(
+        log_file_error, 
+        level="ERROR", 
+        rotation="10 MB", 
+        retention="14 days",
+        format=src.utils.logging.LOG_FORMAT, # Use the actual format string from the module
+        encoding="utf-8"
+    )
+    
+    # Call 2: Debug log file (assuming is_debug might affect this, but testing default path)
+    log_file_debug = os.path.join(src.utils.logging.PROJECT_ROOT, "logs", "debug.log")
+    local_mock_logger.add.assert_any_call(
+        log_file_debug, 
+        level="DEBUG", 
+        rotation="10 MB",
+        retention="7 days",
+        format=src.utils.logging.LOG_FORMAT,
+        encoding="utf-8"
+    )
+    assert local_mock_logger.add.call_count == 2
+
+# End of test file

--- a/tests/utils/test_text_preprocessor.py
+++ b/tests/utils/test_text_preprocessor.py
@@ -1,0 +1,163 @@
+import pytest
+from unittest.mock import patch
+from src.rag_core.utils.text_preprocessor import TextPreprocessor
+
+# --- Test Cases for flatten_levels ---
+
+FLATTEN_LEVELS_TEST_CASES = [
+    # Scenario 1: depth == 1
+    (
+        {"level1": [{"sid": "s1", "text": "t1"}, {"sid": "s2", "text": "t2"}]},
+        1, "input",
+        [
+            {"orig_sid": "s1", "group_uid": "input-s1", "uid": "input-s1", "text": "t1", "side": "input"},
+            {"orig_sid": "s2", "group_uid": "input-s2", "uid": "input-s2", "text": "t2", "side": "input"}
+        ],
+        "depth_1_basic"
+    ),
+    # Scenario 2: depth == 2, perfect match
+    (
+        {"level1": [{"sid": "s1", "text": "t1_l1", "level2": [{"sid": "s1_1", "text": "t1_l2"}]}]},
+        2, "input",
+        [
+            {"orig_sid": "s1", "group_uid": "input-s1_s1_1", "uid": "input-s1_s1_1", "text": "t1_l1\nt1_l2", "side": "input"}
+        ],
+        "depth_2_perfect_match"
+    ),
+    # Scenario 3: depth == 3, data is shallower (ends at level 2)
+    (
+        {"level1": [{"sid": "s1", "text": "t1_l1", "level2": [{"sid": "s1_1", "text": "t1_l2"}]}]},
+        3, "input",
+        [
+            {"orig_sid": "s1", "group_uid": "input-s1_s1_1", "uid": "input-s1_s1_1", "text": "t1_l1\nt1_l2", "side": "input"}
+        ],
+        "depth_3_data_shallower"
+    ),
+    # Scenario 4: depth == 2, data is deeper (has level3, but only processes up to level2 text/uid)
+    (
+        {"level1": [{"sid": "s1", "text": "t1_l1", "level2": [{"sid": "s1_1", "text": "t1_l2", "level3": [{"sid": "s1_1_1", "text": "t1_l3"}]}]}]},
+        2, "input",
+        [
+            {"orig_sid": "s1", "group_uid": "input-s1_s1_1", "uid": "input-s1_s1_1", "text": "t1_l1\nt1_l2", "side": "input"}
+        ],
+        "depth_2_data_deeper"
+    ),
+    # Scenario 5: Missing levelX key (e.g., level2 missing when depth >= 2)
+    (
+        {"level1": [{"sid": "s1", "text": "t1_l1"}]}, # No level2 key
+        2, "input",
+        [
+            {"orig_sid": "s1", "group_uid": "input-s1", "uid": "input-s1", "text": "t1_l1", "side": "input"}
+        ],
+        "depth_2_missing_level2_key"
+    ),
+    # Scenario 6: Missing sid or text in items
+    (
+        {"level1": [{"text": "t_no_sid"}, {"sid": "s_no_text"}]},
+        1, "input",
+        [
+            {"orig_sid": "", "group_uid": "input-", "uid": "input-", "text": "t_no_sid", "side": "input"},
+            {"orig_sid": "s_no_text", "group_uid": "input-s_no_text", "uid": "input-s_no_text", "text": "", "side": "input"}
+        ],
+        "depth_1_missing_sid_or_text"
+    ),
+    # Scenario 7: Empty levelX list (e.g., level2: [] when depth >= 2)
+    (
+        {"level1": [{"sid": "s1", "text": "t1", "level2": []}]},
+        2, "input",
+        [
+            {"orig_sid": "s1", "group_uid": "input-s1", "uid": "input-s1", "text": "t1", "side": "input"}
+        ],
+        "depth_2_empty_level2_list"
+    ),
+    # Scenario 8a: Empty input data
+    (
+        {}, 2, "input", [], "empty_input_data"
+    ),
+    # Scenario 8b: No level1 (or level1 is empty list)
+    (
+        {"level1": []}, 2, "input", [], "empty_level1_list"
+    ),
+    # Additional test: multiple items at level 1, some with deeper levels, some not
+    (
+        {"level1": [
+            {"sid": "s1", "text": "t1_l1", "level2": [{"sid": "s1_1", "text": "t1_l2"}]},
+            {"sid": "s2", "text": "t2_l1"}
+        ]},
+        2, "ref",
+        [
+            {"orig_sid": "s1", "group_uid": "ref-s1_s1_1", "uid": "ref-s1_s1_1", "text": "t1_l1\nt1_l2", "side": "ref"},
+            {"orig_sid": "s2", "group_uid": "ref-s2", "uid": "ref-s2", "text": "t2_l1", "side": "ref"}
+        ],
+        "depth_2_mixed_items"
+    ),
+    # Additional test: depth 3, data goes to level 3
+    (
+        {"level1": [{"sid": "s1", "text": "t1_l1", "level2": [{"sid": "s1_1", "text": "t1_l2", "level3": [{"sid": "s1_1_1", "text": "t1_l3"}]}]}]},
+        3, "input",
+        [
+            {"orig_sid": "s1", "group_uid": "input-s1_s1_1_s1_1_1", "uid": "input-s1_s1_1_s1_1_1", "text": "t1_l1\nt1_l2\nt1_l3", "side": "input"}
+        ],
+        "depth_3_full_match"
+    ),
+    # Additional test: item with missing text at deeper level
+     (
+        {"level1": [{"sid": "s1", "text": "t1_l1", "level2": [{"sid": "s1_1"}]}]}, # s1_1 has no text
+        2, "input",
+        [
+            {"orig_sid": "s1", "group_uid": "input-s1_s1_1", "uid": "input-s1_s1_1", "text": "t1_l1\n", "side": "input"} # Note the trailing newline
+        ],
+        "depth_2_missing_text_deeper"
+    ),
+]
+
+@pytest.mark.parametrize("data, depth, side, expected_output, test_id", FLATTEN_LEVELS_TEST_CASES)
+def test_flatten_levels(data, depth, side, expected_output, test_id):
+    assert TextPreprocessor.flatten_levels(data, depth, side) == expected_output, f"Test ID: {test_id}"
+
+
+# --- Test Cases for chunk_text ---
+
+CHUNK_TEXT_TEST_CASES = [
+    # Scenario 1: max_len <= 0
+    ("test", 0, ["test"], "max_len_zero"),
+    ("test", -5, ["test"], "max_len_negative"),
+    # Scenario 2: Text length <= max_len
+    ("short", 10, ["short"], "text_shorter_than_max_len"),
+    ("exact", 5, ["exact"], "text_exact_max_len"),
+    # Scenario 3: Text length > max_len
+    ("longexampletext", 5, ["longe", "xampl", "etext"], "text_longer_than_max_len_no_padding"),
+    ("another example", 7, ["another", " exampl", "e"], "text_longer_with_spaces"),
+    ("onemore", 3, ["one", "mor", "e"], "text_longer_odd_len"),
+    ("", 5, [""], "empty_string_input"), # Edge case: empty string
+]
+
+@pytest.mark.parametrize("text, max_len, expected_chunks, test_id", CHUNK_TEXT_TEST_CASES)
+def test_chunk_text_various_scenarios(text, max_len, expected_chunks, test_id):
+    assert TextPreprocessor.chunk_text(text, max_len) == expected_chunks, f"Test ID: {test_id}"
+
+def test_chunk_text_utf8_warning(mocker):
+    """
+    Scenario 4: Warning for UTF-8 length.
+    Text: "你好世界" (UTF-8 bytes: 12 chars: 4). max_len=3 (chars).
+    Use mocker.patch('builtins.print').
+    Assert print called and result is correct.
+    """
+    mocked_print = mocker.patch('builtins.print')
+    text_chinese = "你好世界" # Each char is 3 bytes in UTF-8
+    max_len_chars = 3
+    
+    # Expected behavior: chunks by characters, but warns if byte length of original text > max_len
+    # The warning condition in the code is `len(text.encode('utf-8')) > max_len`
+    # This seems like a potential misunderstanding in the original code's warning logic,
+    # as max_len is for characters, not bytes.
+    # However, we test the code as written.
+    # If max_len is 3 (chars), len(text.encode('utf-8')) which is 12 > 3, so warning should appear.
+    
+    expected_chunks = ["你好世", "界"]
+    result = TextPreprocessor.chunk_text(text_chinese, max_len_chars)
+    
+    assert result == expected_chunks
+    mocked_print.assert_called_once_with(f"[chunk_text] Warning: text utf8-len={len(text_chinese.encode('utf-8'))} > {max_len_chars}, might chunk incorrectly.")
+
+# End of test file

--- a/tests/utils/test_token_counter.py
+++ b/tests/utils/test_token_counter.py
@@ -1,0 +1,191 @@
+import pytest
+from unittest.mock import MagicMock, patch
+
+from src.rag_core.utils.token_counter import TokenCounter
+
+# --- Fixtures ---
+
+@pytest.fixture(autouse=True)
+def clear_enc_cache():
+    """Automatically clears TokenCounter._enc_cache before each test run."""
+    TokenCounter._enc_cache.clear()
+    yield # Ensure cleanup happens after test if needed, though clear() is usually enough
+
+@pytest.fixture
+def mock_tiktoken_encoding_for_model(mocker):
+    """Mocks tiktoken.encoding_for_model."""
+    return mocker.patch('src.rag_core.utils.token_counter.encoding_for_model')
+
+@pytest.fixture
+def mock_tiktoken_get_encoding(mocker):
+    """Mocks tiktoken.get_encoding."""
+    return mocker.patch('src.rag_core.utils.token_counter.get_encoding')
+
+@pytest.fixture
+def mock_encoder(mocker):
+    """Creates a generic mock encoder object."""
+    encoder = MagicMock()
+    encoder.encode = MagicMock()
+    encoder.decode = MagicMock()
+    return encoder
+
+# --- Test Classes ---
+
+class TestTokenCounterGetEncoder: # Implicitly tested via public methods
+    def test_get_encoder_model_found_by_encoding_for_model(
+        self, mock_tiktoken_encoding_for_model, mock_tiktoken_get_encoding, mock_encoder
+    ):
+        """
+        _get_encoder Scenario 1: Model found by encoding_for_model.
+        - mock_encoding_for_model returns a specific mock encoder for "gpt-4".
+        - Call TokenCounter.count("text", "gpt-4"). mock_encoding_for_model called.
+        - Call TokenCounter.count("text2", "gpt-4") again. mock_encoding_for_model NOT called (cache hit).
+        """
+        model_name = "gpt-4"
+        mock_tiktoken_encoding_for_model.return_value = mock_encoder
+        mock_encoder.encode.return_value = [1, 2, 3] # Dummy encode output
+
+        # First call
+        TokenCounter.count("text", model_name)
+        mock_tiktoken_encoding_for_model.assert_called_once_with(model_name)
+        mock_tiktoken_get_encoding.assert_not_called()
+        mock_encoder.encode.assert_called_once_with("text")
+
+        # Reset mock call counts for the next assertion
+        mock_tiktoken_encoding_for_model.reset_mock()
+        mock_encoder.encode.reset_mock()
+        
+        # Second call (cache hit)
+        TokenCounter.count("text2", model_name)
+        mock_tiktoken_encoding_for_model.assert_not_called()
+        mock_tiktoken_get_encoding.assert_not_called()
+        mock_encoder.encode.assert_called_once_with("text2") # Encoder from cache is used
+
+    def test_get_encoder_model_not_found_fallback_to_get_encoding(
+        self, mock_tiktoken_encoding_for_model, mock_tiktoken_get_encoding, mock_encoder
+    ):
+        """
+        _get_encoder Scenario 2: Model not found, fallback to get_encoding("cl100k_base").
+        - mock_encoding_for_model raises KeyError for "unknown_model".
+        - mock_get_encoding returns "fallback_encoder" for "cl100k_base".
+        - Call TokenCounter.count for "unknown_model". Both mocks called.
+        - Call TokenCounter.count again for "unknown_model". Neither mock called (cache hit).
+        """
+        unknown_model_name = "unknown_model"
+        fallback_encoder_name = "cl100k_base"
+        
+        mock_tiktoken_encoding_for_model.side_effect = KeyError("Model not found by encoding_for_model")
+        
+        # Create a different mock encoder for the fallback to distinguish
+        fallback_mock_encoder = MagicMock()
+        fallback_mock_encoder.encode.return_value = [10, 20]
+        mock_tiktoken_get_encoding.return_value = fallback_mock_encoder
+
+        # First call
+        TokenCounter.count("text", unknown_model_name)
+        mock_tiktoken_encoding_for_model.assert_called_once_with(unknown_model_name)
+        mock_tiktoken_get_encoding.assert_called_once_with(fallback_encoder_name)
+        fallback_mock_encoder.encode.assert_called_once_with("text")
+
+        # Reset mock call counts
+        mock_tiktoken_encoding_for_model.reset_mock()
+        mock_tiktoken_get_encoding.reset_mock()
+        fallback_mock_encoder.encode.reset_mock()
+
+        # Second call (cache hit for fallback)
+        TokenCounter.count("text2", unknown_model_name)
+        mock_tiktoken_encoding_for_model.assert_not_called()
+        mock_tiktoken_get_encoding.assert_not_called()
+        fallback_mock_encoder.encode.assert_called_once_with("text2")
+
+
+class TestTokenCounterCount:
+    def test_count_basic(self, mock_tiktoken_encoding_for_model, mock_encoder):
+        """
+        count Scenario 1: Basic count.
+        - Mock mock_encoder.encode("test text") to return [10, 20, 30].
+        - mock_encoding_for_model.return_value = mock_encoder.
+        - Assert TokenCounter.count("test text", "gpt-4o") == 3.
+        """
+        test_text = "test text"
+        model_name = "gpt-4o"
+        expected_tokens = [10, 20, 30]
+        
+        mock_encoder.encode.return_value = expected_tokens
+        mock_tiktoken_encoding_for_model.return_value = mock_encoder
+        
+        count = TokenCounter.count(test_text, model_name)
+        
+        assert count == len(expected_tokens)
+        mock_encoder.encode.assert_called_once_with(test_text)
+        mock_tiktoken_encoding_for_model.assert_called_once_with(model_name)
+
+    # Model usage verification is implicitly covered by TestTokenCounterGetEncoder tests.
+
+class TestTokenCounterTruncate:
+    def test_truncate_occurs(self, mock_tiktoken_encoding_for_model, mock_encoder):
+        """
+        truncate Scenario 1: Truncation occurs.
+        - mock_encoder.encode("long example text") returns [1,2,3,4,5].
+        - mock_encoder.decode([1,2,3]) returns "long exa".
+        - Assert TokenCounter.truncate("long example text", 3, "gpt-4o") == "long exa".
+        """
+        full_text = "long example text"
+        truncated_text = "long exa"
+        max_tokens = 3
+        model_name = "gpt-4o"
+        
+        mock_encoder.encode.return_value = [1, 2, 3, 4, 5]
+        mock_encoder.decode.return_value = truncated_text
+        mock_tiktoken_encoding_for_model.return_value = mock_encoder
+        
+        result = TokenCounter.truncate(full_text, max_tokens, model_name)
+        
+        assert result == truncated_text
+        mock_encoder.encode.assert_called_once_with(full_text)
+        mock_encoder.decode.assert_called_once_with([1, 2, 3]) # Tokens up to max_tokens
+        mock_tiktoken_encoding_for_model.assert_called_once_with(model_name)
+
+    def test_truncate_no_truncation_needed(self, mock_tiktoken_encoding_for_model, mock_encoder):
+        """
+        truncate Scenario 2: No truncation (max_tokens > actual tokens).
+        - mock_encoder.encode("short text") returns [1,2].
+        - Assert TokenCounter.truncate("short text", 5, "gpt-4o") == "short text".
+        - mock_encoder.decode should NOT be called.
+        """
+        short_text = "short text"
+        max_tokens = 5
+        model_name = "gpt-4o"
+        
+        mock_encoder.encode.return_value = [1, 2]
+        mock_tiktoken_encoding_for_model.return_value = mock_encoder
+        
+        result = TokenCounter.truncate(short_text, max_tokens, model_name)
+        
+        assert result == short_text
+        mock_encoder.encode.assert_called_once_with(short_text)
+        mock_encoder.decode.assert_not_called() # Crucial: decode not called if no truncation
+        mock_tiktoken_encoding_for_model.assert_called_once_with(model_name)
+
+    @pytest.mark.parametrize("max_tokens_val", [0, -1, -10])
+    def test_truncate_max_tokens_less_than_or_equal_to_zero(
+        self, mock_tiktoken_encoding_for_model, mock_tiktoken_get_encoding, max_tokens_val
+    ):
+        """
+        truncate Scenario 3: max_tokens <= 0.
+        - Assert TokenCounter.truncate("any text", 0, "gpt-4o") == "any text".
+        - Assert TokenCounter.truncate("any text", -1, "gpt-4o") == "any text".
+        - Ensure tiktoken functions were NOT called.
+        """
+        text_to_truncate = "any text"
+        model_name = "gpt-4o" # Model name doesn't matter here as it shouldn't be used
+        
+        result = TokenCounter.truncate(text_to_truncate, max_tokens_val, model_name)
+        
+        assert result == text_to_truncate
+        mock_tiktoken_encoding_for_model.assert_not_called()
+        mock_tiktoken_get_encoding.assert_not_called()
+
+    # Model usage verification is implicitly covered by TestTokenCounterGetEncoder tests.
+
+# End of test file


### PR DESCRIPTION
This commit introduces a standardized and extensive suite of unit tests covering the majority of the project's core logic modules. Pytest is used as the testing framework, with pytest-mock for mocking dependencies.

Modules and components tested include:

Application Layer (`src/rag_core/application`):
- RAGEngine: Core RAG pipeline logic, including async operations and error handling.
- PromptBuilder: Prompt construction with token limiting and scenario handling.

Domain Layer (`src/rag_core/domain`):
- DataStructureChecker: Validation of hierarchical data structures.

Infrastructure Layer (`src/rag_core/infrastructure`):
- EmbeddingManager: Text embedding generation.
- LLMManager: Management of different LLM adapters.
- OpenAIAdapter: OpenAI LLM interaction, including retries and streaming.
- LocalLlamaAdapter: Placeholder structure for local LLM interaction.
- VectorIndex: Vector store operations (Qdrant client interactions mocked).

Utilities (`src/rag_core/utils` and `src/utils`):
- TokenCounter: Text tokenization and truncation.
- TextPreprocessor: Hierarchical data flattening and text chunking.
- BlacklistManager: Substring-based blacklist checking.
- Logging: Configuration and wrapping of the loguru logger.

Configuration (`src/config`):
- Settings: Loading and management of application settings from Pydantic models, environment variables, and YAML files.

Interfaces (`src/interfaces`):
- Helper functions in `cli_main.py` (`load_json_file`, `setup_core`) were tested to ensure correct file handling and core component initialization logic.

The tests aim for thorough coverage of different scenarios, including happy paths, error conditions, edge cases, and interactions with mocked dependencies. This suite significantly improves the robustness and maintainability of the codebase by providing a strong safety net for future development and refactoring.